### PR TITLE
チェックダイアログに閉じるボタンを追加

### DIFF
--- a/lib/components/check_dialog.dart
+++ b/lib/components/check_dialog.dart
@@ -7,14 +7,20 @@ class CheckDialog extends StatelessWidget {
   Widget build(BuildContext context) {
     return Dialog(
       shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(10)),
-      child: const Padding(
-        padding: EdgeInsets.all(20),
+      child: Padding(
+        padding: const EdgeInsets.all(20),
         child: Column(
           mainAxisSize: MainAxisSize.min,
           mainAxisAlignment: MainAxisAlignment.center,
           children: [
-            Text('✔️', style: TextStyle(fontSize: 40)),
-            Text('処理が完了しました')
+            const Text('✔️', style: TextStyle(fontSize: 40)),
+            const Text('処理が完了しました'),
+            TextButton(
+              onPressed: () {
+                Navigator.of(context, rootNavigator: true).pop();
+              },
+              child: const Text('閉じる'),
+            )
           ],
         ),
       ),


### PR DESCRIPTION
## 概要
チェックダイアログに閉じるボタンを追加

## 対応issue
#47 

## 更新内容
- チェックダイアログに閉じるボタンを追加

## テスト
1.アプリを起動
2.名刺追加などでカメラを起動
3.シャッターを切り、プレビューを表示
4.保存ボタンを押して正常に処理が完了した場合チェックダイアログが表示される

## 注意点
特になし

## チェックリスト
- [✅ ] コードがローカル環境で動作することを確認しました
- [✅ ] 関連するドキュメントを更新しました
- [✅ ] 変更内容が他の部分に影響を与えないことを確認しました

## スクリーンショット
![IMG_5356](https://github.com/user-attachments/assets/ffee0119-4a0c-43fe-ac16-fa1da3ab261f)

## その他
特になし