### PR TITLE
showCheckDialog関数を追加

### DIFF
--- a/lib/screens/add/display_picture_screen.dart
+++ b/lib/screens/add/display_picture_screen.dart
@@ -63,6 +63,12 @@ class DisplayPictureScreen extends StatelessWidget {
                           await isar.writeTxn(() async {
                             await isar.meishis.put(meishi);
                           });
+
+                          if (context.mounted) {
+                            Navigator.of(context, rootNavigator: true).pop();
+
+                            showCheckDialog(context);
+                          }
                         } catch (e) {
                           if (context.mounted) {
                             Navigator.of(context, rootNavigator: true).pop();


### PR DESCRIPTION
## 概要
display_screenにshowCheckDialog関数を追加し、データベース保存成功時にチェックダイアログを表示

## 対応issue
#52 

## 更新内容
- display_screenにshowCheckDialog関数を入れてダイアログを表示した

## テスト
1.アプリを起動
2.名刺追加などでカメラを起動
3.シャッターを切り、プレビューを表示
4.保存ボタンを押して正常に処理が完了するとチェックダイアログが表示される

## 注意点
特になし

## チェックリスト
- [✅ ] コードがローカル環境で動作することを確認しました
- [✅ ] 関連するドキュメントを更新しました
- [✅ ] 変更内容が他の部分に影響を与えないことを確認しました

## スクリーンショット
<div style="display:flex;">
  <img src="https://github.com/user-attachments/assets/71a4ea08-ec8a-4c49-8f6e-d9fa930dd402"
width="190" alt="スクリーンショット1"  />
  <img src="https://github.com/user-attachments/assets/7e528112-beb1-4dd1-8ffb-226068b4c3ce"
width="190" alt="スクリーンショット1"  />
</div>

## その他
特になし