### PR TITLE
imagePathの保存からimageNameの保存へ変更

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -55,8 +55,10 @@ class MyApp extends StatelessWidget {
       GoRoute(
         path: '/display_picture',
         builder: (BuildContext context, GoRouterState state) {
+          final imageName = state.uri.queryParameters['imageName']!;
           final imagePath = state.uri.queryParameters['imagePath']!;
           return DisplayPictureScreen(
+            imageName: imageName,
             imagePath: imagePath,
           );
         },

--- a/lib/models/meishi.dart
+++ b/lib/models/meishi.dart
@@ -6,6 +6,6 @@ part 'meishi.g.dart';
 class Meishi {
   Id id = Isar.autoIncrement;
 
-  late String imagePath;
+  late String imageName;
   late DateTime addedTime;
 }

--- a/lib/models/meishi.g.dart
+++ b/lib/models/meishi.g.dart
@@ -22,9 +22,9 @@ const MeishiSchema = CollectionSchema(
       name: r'addedTime',
       type: IsarType.dateTime,
     ),
-    r'imagePath': PropertySchema(
+    r'imageName': PropertySchema(
       id: 1,
-      name: r'imagePath',
+      name: r'imageName',
       type: IsarType.string,
     )
   },
@@ -48,7 +48,7 @@ int _meishiEstimateSize(
   Map<Type, List<int>> allOffsets,
 ) {
   var bytesCount = offsets.last;
-  bytesCount += 3 + object.imagePath.length * 3;
+  bytesCount += 3 + object.imageName.length * 3;
   return bytesCount;
 }
 
@@ -59,7 +59,7 @@ void _meishiSerialize(
   Map<Type, List<int>> allOffsets,
 ) {
   writer.writeDateTime(offsets[0], object.addedTime);
-  writer.writeString(offsets[1], object.imagePath);
+  writer.writeString(offsets[1], object.imageName);
 }
 
 Meishi _meishiDeserialize(
@@ -71,7 +71,7 @@ Meishi _meishiDeserialize(
   final object = Meishi();
   object.addedTime = reader.readDateTime(offsets[0]);
   object.id = id;
-  object.imagePath = reader.readString(offsets[1]);
+  object.imageName = reader.readString(offsets[1]);
   return object;
 }
 
@@ -284,20 +284,20 @@ extension MeishiQueryFilter on QueryBuilder<Meishi, Meishi, QFilterCondition> {
     });
   }
 
-  QueryBuilder<Meishi, Meishi, QAfterFilterCondition> imagePathEqualTo(
+  QueryBuilder<Meishi, Meishi, QAfterFilterCondition> imageNameEqualTo(
     String value, {
     bool caseSensitive = true,
   }) {
     return QueryBuilder.apply(this, (query) {
       return query.addFilterCondition(FilterCondition.equalTo(
-        property: r'imagePath',
+        property: r'imageName',
         value: value,
         caseSensitive: caseSensitive,
       ));
     });
   }
 
-  QueryBuilder<Meishi, Meishi, QAfterFilterCondition> imagePathGreaterThan(
+  QueryBuilder<Meishi, Meishi, QAfterFilterCondition> imageNameGreaterThan(
     String value, {
     bool include = false,
     bool caseSensitive = true,
@@ -305,14 +305,14 @@ extension MeishiQueryFilter on QueryBuilder<Meishi, Meishi, QFilterCondition> {
     return QueryBuilder.apply(this, (query) {
       return query.addFilterCondition(FilterCondition.greaterThan(
         include: include,
-        property: r'imagePath',
+        property: r'imageName',
         value: value,
         caseSensitive: caseSensitive,
       ));
     });
   }
 
-  QueryBuilder<Meishi, Meishi, QAfterFilterCondition> imagePathLessThan(
+  QueryBuilder<Meishi, Meishi, QAfterFilterCondition> imageNameLessThan(
     String value, {
     bool include = false,
     bool caseSensitive = true,
@@ -320,14 +320,14 @@ extension MeishiQueryFilter on QueryBuilder<Meishi, Meishi, QFilterCondition> {
     return QueryBuilder.apply(this, (query) {
       return query.addFilterCondition(FilterCondition.lessThan(
         include: include,
-        property: r'imagePath',
+        property: r'imageName',
         value: value,
         caseSensitive: caseSensitive,
       ));
     });
   }
 
-  QueryBuilder<Meishi, Meishi, QAfterFilterCondition> imagePathBetween(
+  QueryBuilder<Meishi, Meishi, QAfterFilterCondition> imageNameBetween(
     String lower,
     String upper, {
     bool includeLower = true,
@@ -336,7 +336,7 @@ extension MeishiQueryFilter on QueryBuilder<Meishi, Meishi, QFilterCondition> {
   }) {
     return QueryBuilder.apply(this, (query) {
       return query.addFilterCondition(FilterCondition.between(
-        property: r'imagePath',
+        property: r'imageName',
         lower: lower,
         includeLower: includeLower,
         upper: upper,
@@ -346,69 +346,69 @@ extension MeishiQueryFilter on QueryBuilder<Meishi, Meishi, QFilterCondition> {
     });
   }
 
-  QueryBuilder<Meishi, Meishi, QAfterFilterCondition> imagePathStartsWith(
+  QueryBuilder<Meishi, Meishi, QAfterFilterCondition> imageNameStartsWith(
     String value, {
     bool caseSensitive = true,
   }) {
     return QueryBuilder.apply(this, (query) {
       return query.addFilterCondition(FilterCondition.startsWith(
-        property: r'imagePath',
+        property: r'imageName',
         value: value,
         caseSensitive: caseSensitive,
       ));
     });
   }
 
-  QueryBuilder<Meishi, Meishi, QAfterFilterCondition> imagePathEndsWith(
+  QueryBuilder<Meishi, Meishi, QAfterFilterCondition> imageNameEndsWith(
     String value, {
     bool caseSensitive = true,
   }) {
     return QueryBuilder.apply(this, (query) {
       return query.addFilterCondition(FilterCondition.endsWith(
-        property: r'imagePath',
+        property: r'imageName',
         value: value,
         caseSensitive: caseSensitive,
       ));
     });
   }
 
-  QueryBuilder<Meishi, Meishi, QAfterFilterCondition> imagePathContains(
+  QueryBuilder<Meishi, Meishi, QAfterFilterCondition> imageNameContains(
       String value,
       {bool caseSensitive = true}) {
     return QueryBuilder.apply(this, (query) {
       return query.addFilterCondition(FilterCondition.contains(
-        property: r'imagePath',
+        property: r'imageName',
         value: value,
         caseSensitive: caseSensitive,
       ));
     });
   }
 
-  QueryBuilder<Meishi, Meishi, QAfterFilterCondition> imagePathMatches(
+  QueryBuilder<Meishi, Meishi, QAfterFilterCondition> imageNameMatches(
       String pattern,
       {bool caseSensitive = true}) {
     return QueryBuilder.apply(this, (query) {
       return query.addFilterCondition(FilterCondition.matches(
-        property: r'imagePath',
+        property: r'imageName',
         wildcard: pattern,
         caseSensitive: caseSensitive,
       ));
     });
   }
 
-  QueryBuilder<Meishi, Meishi, QAfterFilterCondition> imagePathIsEmpty() {
+  QueryBuilder<Meishi, Meishi, QAfterFilterCondition> imageNameIsEmpty() {
     return QueryBuilder.apply(this, (query) {
       return query.addFilterCondition(FilterCondition.equalTo(
-        property: r'imagePath',
+        property: r'imageName',
         value: '',
       ));
     });
   }
 
-  QueryBuilder<Meishi, Meishi, QAfterFilterCondition> imagePathIsNotEmpty() {
+  QueryBuilder<Meishi, Meishi, QAfterFilterCondition> imageNameIsNotEmpty() {
     return QueryBuilder.apply(this, (query) {
       return query.addFilterCondition(FilterCondition.greaterThan(
-        property: r'imagePath',
+        property: r'imageName',
         value: '',
       ));
     });
@@ -432,15 +432,15 @@ extension MeishiQuerySortBy on QueryBuilder<Meishi, Meishi, QSortBy> {
     });
   }
 
-  QueryBuilder<Meishi, Meishi, QAfterSortBy> sortByImagePath() {
+  QueryBuilder<Meishi, Meishi, QAfterSortBy> sortByImageName() {
     return QueryBuilder.apply(this, (query) {
-      return query.addSortBy(r'imagePath', Sort.asc);
+      return query.addSortBy(r'imageName', Sort.asc);
     });
   }
 
-  QueryBuilder<Meishi, Meishi, QAfterSortBy> sortByImagePathDesc() {
+  QueryBuilder<Meishi, Meishi, QAfterSortBy> sortByImageNameDesc() {
     return QueryBuilder.apply(this, (query) {
-      return query.addSortBy(r'imagePath', Sort.desc);
+      return query.addSortBy(r'imageName', Sort.desc);
     });
   }
 }
@@ -470,15 +470,15 @@ extension MeishiQuerySortThenBy on QueryBuilder<Meishi, Meishi, QSortThenBy> {
     });
   }
 
-  QueryBuilder<Meishi, Meishi, QAfterSortBy> thenByImagePath() {
+  QueryBuilder<Meishi, Meishi, QAfterSortBy> thenByImageName() {
     return QueryBuilder.apply(this, (query) {
-      return query.addSortBy(r'imagePath', Sort.asc);
+      return query.addSortBy(r'imageName', Sort.asc);
     });
   }
 
-  QueryBuilder<Meishi, Meishi, QAfterSortBy> thenByImagePathDesc() {
+  QueryBuilder<Meishi, Meishi, QAfterSortBy> thenByImageNameDesc() {
     return QueryBuilder.apply(this, (query) {
-      return query.addSortBy(r'imagePath', Sort.desc);
+      return query.addSortBy(r'imageName', Sort.desc);
     });
   }
 }
@@ -490,10 +490,10 @@ extension MeishiQueryWhereDistinct on QueryBuilder<Meishi, Meishi, QDistinct> {
     });
   }
 
-  QueryBuilder<Meishi, Meishi, QDistinct> distinctByImagePath(
+  QueryBuilder<Meishi, Meishi, QDistinct> distinctByImageName(
       {bool caseSensitive = true}) {
     return QueryBuilder.apply(this, (query) {
-      return query.addDistinctBy(r'imagePath', caseSensitive: caseSensitive);
+      return query.addDistinctBy(r'imageName', caseSensitive: caseSensitive);
     });
   }
 }
@@ -511,9 +511,9 @@ extension MeishiQueryProperty on QueryBuilder<Meishi, Meishi, QQueryProperty> {
     });
   }
 
-  QueryBuilder<Meishi, String, QQueryOperations> imagePathProperty() {
+  QueryBuilder<Meishi, String, QQueryOperations> imageNameProperty() {
     return QueryBuilder.apply(this, (query) {
-      return query.addPropertyName(r'imagePath');
+      return query.addPropertyName(r'imageName');
     });
   }
 }

--- a/lib/screens/add/camera_screen.dart
+++ b/lib/screens/add/camera_screen.dart
@@ -51,15 +51,13 @@ class _CameraScreenState extends State<CameraScreen> {
           padding: const EdgeInsets.only(bottom: 60),
           child: Align(
               alignment: Alignment.bottomCenter,
-              child: CaptureButton(
-                onPressed: () async {
-                  final image = await _controller.takePicture();
-                  if (context.mounted) {
-                    context.push(
-                        '/display_picture?imagePath=${Uri.encodeComponent(image.path)}');
-                  }
-                },
-              )),
+              child: CaptureButton(onPressed: () async {
+                final image = await _controller.takePicture();
+                if (context.mounted) {
+                  context.push(
+                      '/display_picture?imageName=${Uri.encodeComponent(image.name)}&imagePath=${Uri.encodeComponent(image.path)}');
+                }
+              })),
         ),
       ],
     );

--- a/lib/screens/add/display_picture_screen.dart
+++ b/lib/screens/add/display_picture_screen.dart
@@ -7,7 +7,9 @@ import 'package:e_meishi/utils/utils.dart';
 import 'package:path_provider/path_provider.dart';
 
 class DisplayPictureScreen extends StatelessWidget {
-  const DisplayPictureScreen({super.key, required this.imagePath});
+  const DisplayPictureScreen(
+      {super.key, required this.imageName, required this.imagePath});
+  final String imageName;
   final String imagePath;
 
   @override
@@ -52,7 +54,7 @@ class DisplayPictureScreen extends StatelessWidget {
                         try {
                           // 非同期処理
                           final meishi = Meishi()
-                            ..imagePath = imagePath
+                            ..imageName = imageName
                             ..addedTime = DateTime.now();
                           final dir = await getApplicationDocumentsDirectory();
                           final isar = await Isar.open(

--- a/lib/screens/add/display_picture_screen.dart
+++ b/lib/screens/add/display_picture_screen.dart
@@ -9,8 +9,8 @@ import 'package:path_provider/path_provider.dart';
 class DisplayPictureScreen extends StatelessWidget {
   const DisplayPictureScreen(
       {super.key, required this.imageName, required this.imagePath});
-  final String imageName;
-  final String imagePath;
+  final String imageName; //imageNameはIsarに保存。
+  final String imagePath; //imagePathはプレビューにのみ使用。(都度絶対パスが変更される可能性があるため)
 
   @override
   Widget build(BuildContext context) {


### PR DESCRIPTION
## 概要
imagePathの保存からimageNameの保存へ変更した
cameraからdisplay_pictureに渡すパラメータとisarに保存するデータを修正

## 対応issue
#40 
#62 

## 更新内容
- meishiコレクションのimagePathフィールドを削除
- meishiコレクションにimageNameフィールドを追加
- display_pictureに渡すパラメータにimageNameを追加
- imageNameをisarに保存し、imagePathはプレビュー専用にした

## テスト
1.アプリを起動
2.カメラを起動
3.シャッターを切る
4.プレビューが正しく出現するか確認(imagePathが機能している)
4.保存を押す
5.データベースに保存されているデータを確認(imageNameが機能しているか)

## 注意点
- 仮として最低限のプロパティを宣言しています
- 現状はこれで定義していますが、何か不備がある場合は修正/追加していく予定です
- imagePathはプレビュー専用としています(絶対パスは都度変更されるため)
- imageNameをDBに保存し、表示毎に絶対パスを再構築する予定です(このためimageNameを保存する)

## スクリーンショット
見た目自体は変化がないため割愛

## その他
この時点ではプレビューから保存のステップを修正しただけなので、保存した名刺を表示することはできません
(次のブランチで開発します)