### PR TITLE
myMeishiViewコンポーネントを作成

### DIFF
--- a/lib/components/my_meishi_view.dart
+++ b/lib/components/my_meishi_view.dart
@@ -1,0 +1,58 @@
+import 'package:e_meishi/models/meishi.dart';
+import 'package:flutter/material.dart';
+import 'dart:io';
+import 'package:isar/isar.dart';
+import 'package:go_router/go_router.dart';
+import 'package:path_provider/path_provider.dart';
+
+class MyMeishiView extends StatelessWidget {
+  final int meishiId;
+
+  const MyMeishiView({super.key, required this.meishiId});
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(children: [
+      ElevatedButton(
+        onPressed: () => context.go('/home'), // /homeに遷移
+        child: const Text('戻る'), // ボタンのテキスト
+      ),
+      FutureBuilder(
+        future: _loadImage(meishiId),
+        builder: (BuildContext context, AsyncSnapshot<String?> snapshot) {
+          // データの取得が進行中かどうかをチェック
+          if (snapshot.connectionState == ConnectionState.waiting) {
+            return const Center(child: CircularProgressIndicator()); // ローディングインジケーターを表示
+          }
+          
+          // エラーが発生した場合
+          if (snapshot.hasError) {
+            return Text('Error: ${snapshot.error}');
+          }
+          
+          // データが存在しない場合やnullの場合
+          if (!snapshot.hasData || snapshot.data == null || snapshot.data!.isEmpty) {
+            return const Text('No image found');
+          }
+          
+          // 画像を表示
+          return Image.file(File(snapshot.data!));
+        },
+      ),
+    ]);
+  }
+}
+
+Future<String?> _loadImage(int id) async {
+  final isar = Isar.getInstance(); // 既に開かれているIsarインスタンスを取得
+  final meishi = await isar?.meishis.get(id); // 直接コレクションにアクセス
+  final dir = await getApplicationDocumentsDirectory();
+  final imageName = meishi?.imageName;
+
+  // imageName が null または空の場合、空の文字列を返す
+  if (imageName == null || imageName.isEmpty) {
+    return '';
+  }
+  
+  return '${dir.path}/camera/pictures/$imageName';
+}

--- a/lib/components/my_meishi_view.dart
+++ b/lib/components/my_meishi_view.dart
@@ -2,7 +2,6 @@ import 'package:e_meishi/models/meishi.dart';
 import 'package:flutter/material.dart';
 import 'dart:io';
 import 'package:isar/isar.dart';
-import 'package:go_router/go_router.dart';
 import 'package:path_provider/path_provider.dart';
 
 class MyMeishiView extends StatelessWidget {
@@ -12,47 +11,53 @@ class MyMeishiView extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Column(children: [
-      ElevatedButton(
-        onPressed: () => context.go('/home'), // /homeに遷移
-        child: const Text('戻る'), // ボタンのテキスト
-      ),
-      FutureBuilder(
-        future: _loadImage(meishiId),
-        builder: (BuildContext context, AsyncSnapshot<String?> snapshot) {
-          // データの取得が進行中かどうかをチェック
-          if (snapshot.connectionState == ConnectionState.waiting) {
-            return const Center(child: CircularProgressIndicator()); // ローディングインジケーターを表示
-          }
-          
-          // エラーが発生した場合
-          if (snapshot.hasError) {
-            return Text('Error: ${snapshot.error}');
-          }
-          
-          // データが存在しない場合やnullの場合
-          if (!snapshot.hasData || snapshot.data == null || snapshot.data!.isEmpty) {
-            return const Text('No image found');
-          }
-          
-          // 画像を表示
-          return Image.file(File(snapshot.data!));
-        },
-      ),
-    ]);
-  }
-}
+    return Scaffold(
+      appBar: AppBar(title: const Text('マイページ')), // AppBarを追加
+      body: Column(children: [
+        FutureBuilder(
+          future: _loadImage(meishiId),
+          builder: (BuildContext context, AsyncSnapshot<String?> snapshot) {
+            // データの取得が進行中かどうかをチェック
+            if (snapshot.connectionState == ConnectionState.waiting) {
+              return const Center(
+                  child: CircularProgressIndicator()); // ローディングインジケーターを表示
+            }
 
-Future<String?> _loadImage(int id) async {
-  final isar = Isar.getInstance(); // 既に開かれているIsarインスタンスを取得
-  final meishi = await isar?.meishis.get(id); // 直接コレクションにアクセス
-  final dir = await getApplicationDocumentsDirectory();
-  final imageName = meishi?.imageName;
+            // エラーが発生した場合
+            if (snapshot.hasError) {
+              return Text('Error: ${snapshot.error}');
+            }
 
-  // imageName が null または空の場合、空の文字列を返す
-  if (imageName == null || imageName.isEmpty) {
-    return '';
+            // データが存在しない場合やnullの場合
+            if (!snapshot.hasData ||
+                snapshot.data == null ||
+                snapshot.data!.isEmpty) {
+              return const Text('No image found');
+            }
+
+            // 画像を表示
+            return Container(
+                margin: const EdgeInsets.all(5),
+                decoration: BoxDecoration(
+                    border: Border.all(color: Colors.grey, width: 3)),
+                child: Image.file(File(snapshot.data!)));
+          },
+        ),
+      ]),
+    );
   }
-  
-  return '${dir.path}/camera/pictures/$imageName';
+
+  Future<String?> _loadImage(int id) async {
+    final isar = Isar.getInstance(); // 既に開かれているIsarインスタンスを取得
+    final meishi = await isar?.meishis.get(id); // 直接コレクションにアクセス
+    final dir = await getApplicationDocumentsDirectory();
+    final imageName = meishi?.imageName;
+
+    // imageName が null または空の場合、空の文字列を返す
+    if (imageName == null || imageName.isEmpty) {
+      return '';
+    }
+
+    return '${dir.path}/camera/pictures/$imageName';
+  }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'screens/Introduction/introduction_screen.dart';
 import 'screens/home/home_screen.dart';
+import 'screens/my_page/my_page_screen.dart';
 import 'package:go_router/go_router.dart';
 import 'package:google_fonts/google_fonts.dart';
 import 'package:camera/camera.dart';
@@ -45,6 +46,12 @@ class MyApp extends StatelessWidget {
         path: '/home',
         builder: (BuildContext context, GoRouterState state) {
           return const HomeScreen();
+        },
+      ),
+      GoRoute(
+        path: '/mypage',
+        builder: (BuildContext context, GoRouterState state) {
+          return const MyPageScreen();
         },
       ),
       GoRoute(

--- a/lib/screens/my_page/my_page_screen.dart
+++ b/lib/screens/my_page/my_page_screen.dart
@@ -1,0 +1,12 @@
+import 'package:flutter/material.dart';
+
+class MyPageScreen extends StatelessWidget {
+  const MyPageScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const MaterialApp(
+      home: MyPageScreen(),
+    );
+  }
+}

--- a/lib/screens/my_page/my_page_screen.dart
+++ b/lib/screens/my_page/my_page_screen.dart
@@ -1,12 +1,13 @@
 import 'package:flutter/material.dart';
+import 'package:e_meishi/components/my_meishi_view.dart';
 
 class MyPageScreen extends StatelessWidget {
   const MyPageScreen({super.key});
 
   @override
   Widget build(BuildContext context) {
-    return const MaterialApp(
-      home: MyPageScreen(),
+    return const MyMeishiView(
+      meishiId: 1,
     );
   }
 }


### PR DESCRIPTION
## 概要
自分の名刺を表示するコンポーネント(myMeishiView)を作成

## 対応issue
#59 

## 更新内容
- myMeishiViewコンポーネントを作成

## テスト
1.アプリを起動
2.マイページへ遷移
3.自分の名刺を確認

## 注意点
ブランチ名がmy-page-uiとなっていますが、myMeishiViewコンポーネントを作成するためのブランチとして活用しました。
当初はマイページのUI全てを作る予定でしたが、規模が大きすぎるため分割します。

名刺のid1を表示しています。
id1は自分の名刺としてしか使用しないため、このような実装になっていますが
もし何かの問題が発生してid:1に自分の名刺以外が入ってしまった場合の対処も必要かもしれません。

## スクリーンショット
<div style="display:flex;">
  <img src="https://github.com/user-attachments/assets/394b7e29-9546-44d2-b1af-c57dfbbf19e0"
width="300" alt="スクリーンショット1"  />
</div>

## その他
特になし