### PR TITLE
遷移用ボタンを作成

### DIFF
--- a/lib/components/my_meishi_view.dart
+++ b/lib/components/my_meishi_view.dart
@@ -11,40 +11,37 @@ class MyMeishiView extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(title: const Text('マイページ')), // AppBarを追加
-      body: Column(children: [
-        FutureBuilder(
-          future: _loadImage(meishiId),
-          builder: (BuildContext context, AsyncSnapshot<String?> snapshot) {
-            // データの取得が進行中かどうかをチェック
-            if (snapshot.connectionState == ConnectionState.waiting) {
-              return const Center(
-                  child: CircularProgressIndicator()); // ローディングインジケーターを表示
-            }
+    return Column(children: [
+      FutureBuilder(
+        future: _loadImage(meishiId),
+        builder: (BuildContext context, AsyncSnapshot<String?> snapshot) {
+          // データの取得が進行中かどうかをチェック
+          if (snapshot.connectionState == ConnectionState.waiting) {
+            return const Center(
+                child: CircularProgressIndicator()); // ローディングインジケーターを表示
+          }
 
-            // エラーが発生した場合
-            if (snapshot.hasError) {
-              return Text('Error: ${snapshot.error}');
-            }
+          // エラーが発生した場合
+          if (snapshot.hasError) {
+            return Text('Error: ${snapshot.error}');
+          }
 
-            // データが存在しない場合やnullの場合
-            if (!snapshot.hasData ||
-                snapshot.data == null ||
-                snapshot.data!.isEmpty) {
-              return const Text('No image found');
-            }
+          // データが存在しない場合やnullの場合
+          if (!snapshot.hasData ||
+              snapshot.data == null ||
+              snapshot.data!.isEmpty) {
+            return const Text('No image found');
+          }
 
-            // 画像を表示
-            return Container(
-                margin: const EdgeInsets.all(5),
-                decoration: BoxDecoration(
-                    border: Border.all(color: Colors.grey, width: 3)),
-                child: Image.file(File(snapshot.data!)));
-          },
-        ),
-      ]),
-    );
+          // 画像を表示
+          return Container(
+              margin: const EdgeInsets.all(5),
+              decoration: BoxDecoration(
+                  border: Border.all(color: Colors.grey, width: 3)),
+              child: Image.file(File(snapshot.data!)));
+        },
+      ),
+    ]);
   }
 
   Future<String?> _loadImage(int id) async {

--- a/lib/components/transition_button.dart
+++ b/lib/components/transition_button.dart
@@ -1,0 +1,45 @@
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+
+class TransitionButton extends StatelessWidget {
+  final String buttonText;
+  final String transtion;
+  final IconData icon;
+
+  const TransitionButton(
+      {super.key,
+      required this.buttonText,
+      required this.transtion,
+      required this.icon});
+
+  @override
+  Widget build(BuildContext context) {
+    return ElevatedButton.icon(
+      onPressed: () {
+        context.push(transtion); // 必要なページに遷移するように変更
+      },
+      icon: Icon(
+        icon, // IconData型のアイコンをそのまま使用
+        size: 24,
+        color: Colors.blue,
+      ),
+      label: Text(
+        buttonText, // ボタンのテキスト
+        style: const TextStyle(
+          fontSize: 16,
+          color: Colors.blue,
+        ),
+      ),
+      style: ElevatedButton.styleFrom(
+        foregroundColor: Colors.blue, // ボタンの背景色
+        backgroundColor: Colors.blue[50],
+        elevation: 0,
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(10), // ボタンの角を丸くする
+        ),
+        padding: const EdgeInsets.symmetric(
+            horizontal: 20, vertical: 12), // パディングを追加
+      ),
+    );
+  }
+}

--- a/lib/screens/my_page/my_page_screen.dart
+++ b/lib/screens/my_page/my_page_screen.dart
@@ -1,13 +1,37 @@
 import 'package:flutter/material.dart';
 import 'package:e_meishi/components/my_meishi_view.dart';
+import 'package:e_meishi/components/transition_button.dart';
 
 class MyPageScreen extends StatelessWidget {
   const MyPageScreen({super.key});
 
   @override
   Widget build(BuildContext context) {
-    return const MyMeishiView(
-      meishiId: 1,
+    return Scaffold(
+      // Scaffoldで画面全体を構成
+      appBar: AppBar(
+        title: const Text('マイページ'),
+      ),
+      body: const SingleChildScrollView(
+        child: Column(
+          // Columnでウィジェットを縦に並べる
+          mainAxisAlignment: MainAxisAlignment.start,
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            MyMeishiView(
+              meishiId: 1,
+            ),
+            Padding(
+              padding: EdgeInsets.all(8.0),
+              child: TransitionButton(
+                buttonText: '過去の名刺を見る',
+                transtion: '/history',
+                icon: Icons.history,
+              ),
+            ),
+          ],
+        ),
+      ),
     );
   }
 }


### PR DESCRIPTION
## 概要
遷移用のボタンを作成し、マイページに設置した

## 対応issue
#60 

## 更新内容
- transition_buttonを作成
- マイページに設置

## テスト
1.アプリを起動
2.マイページへ遷移
3.ボタンと動作を確認(このプルリクではdummyに遷移)

## 注意点
このプルリクのでは遷移先をdummyに設定していますので押しても遷移先がありません

## スクリーンショット
<div style="display:flex;">
  <img src="https://github.com/user-attachments/assets/1c29e64e-bfb4-44ab-a302-9db1f6474a0c"
width="300" alt="スクリーンショット1"  />
</div>

## その他
専用コンポーネントではなく汎用なので、引数でbuttonText,transtion,iconを指定する必要があります。