### PR TITLE
アクティビティアイテムの上にテキストを追加

### DIFF
--- a/lib/components/activities.dart
+++ b/lib/components/activities.dart
@@ -5,18 +5,28 @@ class Activities extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return GridView.builder(
-      shrinkWrap: true,
-      physics: const NeverScrollableScrollPhysics(), // 内部スクロールを無効にする
-      gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
-          crossAxisCount: 3, // グリッドの列数
-          crossAxisSpacing: 8,
-          mainAxisSpacing: 8,
-          childAspectRatio: 1),
-      itemCount: 6,
-      itemBuilder: (context, index) {
-        return _buildActivity(index); // 各アイテムをビルドするメソッドを呼び出し
-      },
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        const Padding(
+          padding: EdgeInsets.only(left: 16, top: 16),
+          child: Text('アクティビティ',
+              style: TextStyle(fontWeight: FontWeight.bold, fontSize: 18)),
+        ), // 新しいテキストを追加
+        GridView.builder(
+          shrinkWrap: true,
+          physics: const NeverScrollableScrollPhysics(), // 内部スクロールを無効にする
+          gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
+              crossAxisCount: 3, // グリッドの列数
+              crossAxisSpacing: 8,
+              mainAxisSpacing: 8,
+              childAspectRatio: 1),
+          itemCount: 6,
+          itemBuilder: (context, index) {
+            return _buildActivity(index); // 各アイテムをビルドするメソッドを呼び出し
+          },
+        ),
+      ],
     );
   }
 }


### PR DESCRIPTION
## 概要
アクティビティアイテムの上にテキストを作成した
若干paddingを調整した

## 対応issue
#82 

## 更新内容
- アクティビティアイテムの上にテキストを配置した
- それに伴って若干Paddingを調整した

## テスト
1.アプリを起動
2.マイページへ遷移
3.テキストを確認

## 注意点
現時点ではデータを仮に設置しています。
完成図としては、ローカルDBを元に実績や活動結果を出して表示する予定です。

## スクリーンショット
<div style="display:flex;">
  <img src="https://github.com/user-attachments/assets/207f6244-e2fc-4ad8-9812-4c5c5ead11b7"
width="300" alt="スクリーンショット1"  />
</div>

## その他
特になし