### PR TITLE
お問い合わせボタンとよくある質問ボタンを追加

### DIFF
--- a/lib/screens/my_page/my_page_screen.dart
+++ b/lib/screens/my_page/my_page_screen.dart
@@ -32,6 +32,34 @@ class MyPageScreen extends StatelessWidget {
               ),
             ),
             Activities(),
+            Padding(
+              padding: EdgeInsets.symmetric(horizontal: 8, vertical: 8),
+              child: Row(
+                children: [
+                  Padding(
+                    padding: EdgeInsets.symmetric(horizontal: 2),
+                    child: Expanded(
+                      child: TransitionButton(
+                        buttonText: 'お問い合わせ',
+                        transtion: '/contact',
+                        icon: Icons.outgoing_mail,
+                      ),
+                    ),
+                  ),
+                  Spacer(),
+                  Padding(
+                    padding: EdgeInsets.symmetric(horizontal: 2),
+                    child: Expanded(
+                      child: TransitionButton(
+                        buttonText: 'よくある質問',
+                        transtion: '/question',
+                        icon: Icons.help,
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            ),
             Request()
           ],
         ),


### PR DESCRIPTION
## 概要
マイページにお問い合わせボタンをよくある質問ボタンを追加した

## 対応issue
#20 
#25 
#86 

## 更新内容
- trasntion_button二つをRowで横並びにした
- それぞれにお問い合わせとよくある質問ボタンを命名

## テスト
1.アプリを起動
2.マイページへ遷移
3.UIを確認

## 注意点
UIだけなので、ボタンを押してもルートがないと言われます。
完成図としては、ボタンを押すと任意の画面に遷移し、ブラウザが開いて外部のサイトを開く仕様にするつもりです

## スクリーンショット
<div style="display:flex;">
  <img src="https://github.com/user-attachments/assets/f15e197e-84b1-4235-9436-bd12b17c6cb7"
width="300" alt="スクリーンショット1"  />
</div>

## その他
特になし