### PR TITLE
ホームページにBigMeishiViewを設置

### DIFF
--- a/lib/components/big_meishi_view.dart
+++ b/lib/components/big_meishi_view.dart
@@ -4,10 +4,10 @@ import 'dart:io';
 import 'package:isar/isar.dart';
 import 'package:path_provider/path_provider.dart';
 
-class MyMeishiView extends StatelessWidget {
+class BigMeishiView extends StatelessWidget {
   final int meishiId;
 
-  const MyMeishiView({super.key, required this.meishiId});
+  const BigMeishiView({super.key, required this.meishiId});
 
   @override
   Widget build(BuildContext context) {

--- a/lib/screens/home/home_screen.dart
+++ b/lib/screens/home/home_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:e_meishi/components/big_meishi_view.dart';
 
 class HomeScreen extends StatelessWidget {
   const HomeScreen({super.key});
@@ -6,15 +7,9 @@ class HomeScreen extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: const Text('ホーム')),
-      body: Center(
-        child: ElevatedButton(
-          child: const Text('次へ'),
-          onPressed: () {
-            print('ホームボタン');
-          },
-        ),
-      ),
-    );
+        appBar: AppBar(title: const Text('ホーム')),
+        body: const Column(
+          children: [BigMeishiView(meishiId: 1)], //仮にmeishiId : 1を指定
+        ));
   }
 }

--- a/lib/screens/my_page/my_page_screen.dart
+++ b/lib/screens/my_page/my_page_screen.dart
@@ -20,7 +20,7 @@ class MyPageScreen extends StatelessWidget {
           mainAxisAlignment: MainAxisAlignment.start,
           crossAxisAlignment: CrossAxisAlignment.stretch,
           children: [
-            MyMeishiView(
+            BigMeishiView(
               meishiId: 1,
             ),
             Padding(


### PR DESCRIPTION
## 概要
ホームページにBigMeishiViewを設置
myMeishiViewのままの記述をBigMeishiViewに修正

## 対応issue
#68 
#71 

## 更新内容
- home_screenにBigMeishiViewを設置
- MyMeishiViewのままの記述をBigMeishiViewに修正

## テスト
1.アプリを起動
2.ホームを開き、表示できているか確認

## 注意点
BigMeishiViewはあくまで仮になので、今後スライダーなどになる可能性はあります。

## スクリーンショット
<div style="display:flex;">
  <img src="https://github.com/user-attachments/assets/475c0c83-7e71-42a9-9b88-62c03e552473"
width="300" alt="スクリーンショット1"  />
</div>

## その他
特になし