### PR TITLE
名刺登録ページへの遷移ボタンを作成,配置

### DIFF
--- a/lib/components/add_meishi_button.dart
+++ b/lib/components/add_meishi_button.dart
@@ -1,0 +1,24 @@
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+
+class AddMeishiButton extends StatelessWidget {
+  const AddMeishiButton({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return TextButton(
+        style: TextButton.styleFrom(
+          backgroundColor: Colors.lightBlueAccent,
+          fixedSize: const Size(70, 70),
+          shape: const CircleBorder(),
+        ),
+        onPressed: () {
+          context.push('/add/meishi');
+        },
+        child: const Icon(
+          Icons.add,
+          color: Colors.white,
+          size: 30,
+        ));
+  }
+}

--- a/lib/screens/home/home_screen.dart
+++ b/lib/screens/home/home_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:e_meishi/components/big_meishi_view.dart';
+import 'package:e_meishi/components/add_meishi_button.dart';
 
 class HomeScreen extends StatelessWidget {
   const HomeScreen({super.key});
@@ -8,8 +9,17 @@ class HomeScreen extends StatelessWidget {
   Widget build(BuildContext context) {
     return Scaffold(
         appBar: AppBar(title: const Text('ホーム')),
-        body: const Column(
-          children: [BigMeishiView(meishiId: 1)], //仮にmeishiId : 1を指定
-        ));
+        body: const Stack(children: [
+          Column(
+            children: [
+              BigMeishiView(meishiId: 1), //仮にmeishiId : 1を指定
+            ],
+          ),
+          Positioned(
+            bottom: kBottomNavigationBarHeight - 30,
+            right: 30,
+            child: AddMeishiButton(),
+          )
+        ]));
   }
 }


### PR DESCRIPTION
## 概要
名刺登録ページへの遷移ボタンを作成
ホームページに名刺登録ページへの遷移ボタンを設置

## 対応issue
#66 

## 更新内容
- add_meishi_buttonを作成
- ホームページにadd_meishi_buttonを右下に固定配置

## テスト
1.アプリを起動
2.ホームを開き、ボタンを確認
3./add/meishiページへ遷移する確認

## 注意点
kBottomNavigaitonButtonでボトムナビゲーションバーの高さを取得していますが、
これだと何故か高さが高くなってしまうので力技で高さを-30しています。

## スクリーンショット
<div style="display:flex;">
  <img src="https://github.com/user-attachments/assets/a0351c97-8331-4c76-b2dc-35229cba1b76"
width="300" alt="スクリーンショット1"  />
</div>

## その他
特になし