### PR TITLE
名刺管理ページのAppBarに検索バーを設置

### DIFF
--- a/lib/components/search_field.dart
+++ b/lib/components/search_field.dart
@@ -1,0 +1,33 @@
+import 'package:flutter/material.dart';
+
+class SearchField extends StatefulWidget {
+  const SearchField({super.key});
+
+  @override
+  State<SearchField> createState() => _SearchFieldState();
+}
+
+class _SearchFieldState extends State<SearchField> {
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      height: kToolbarHeight,
+      padding: const EdgeInsets.all(8),
+      child: Center(
+        child: TextField(
+          decoration: InputDecoration(
+              hintText: '名刺の情報で検索',
+              filled: true,
+              isDense: true,
+              contentPadding: const EdgeInsets.symmetric(vertical: 0),
+              prefixIcon: const Icon(Icons.search),
+              border: OutlineInputBorder(
+                  borderRadius: BorderRadius.circular(30),
+                  borderSide: BorderSide.none)),
+          onChanged: (value) {},
+          textAlignVertical: TextAlignVertical.center,
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/management/management_screen.dart
+++ b/lib/screens/management/management_screen.dart
@@ -1,10 +1,15 @@
 import 'package:flutter/material.dart';
+import 'package:e_meishi/components/search_field.dart';
 
 class ManagementScreen extends StatelessWidget {
   const ManagementScreen({super.key});
 
   @override
   Widget build(BuildContext context) {
-    return const Text('名刺管理ページ');
+    return Scaffold(
+      appBar: AppBar(
+        title: const SearchField(),
+      ),
+    );
   }
 }


### PR DESCRIPTION
## 概要
検索バーを作成し名刺管理ページに設置した

## 対応issue
#98 

## 更新内容
- search_fieldを作成
- management_screenのAppBarにsearch_fieldを設置

## テスト
1.アプリを起動
2.名刺管理ページを開く
3.検索バーを確認

## 注意点
検索バーの命名がsearch_barでなくsearch_fieldなのはMaterialと名前が競合してしまうみたいなので近しい意味のクラス名にしました。
UIや機能は一般的な検索バーと同じです。

## スクリーンショット
<div style="display:flex;">
  <img src="https://github.com/user-attachments/assets/3d256315-8b5b-46f8-84a3-393fa64e788e"
width="300" alt="スクリーンショット1"  />
</div>

## その他
特になし