### PR TITLE
名刺管理ページのソートと名刺表示セクションを作成

### DIFF
--- a/lib/components/grid_cards.dart
+++ b/lib/components/grid_cards.dart
@@ -1,0 +1,29 @@
+import 'package:flutter/material.dart';
+
+class GridCards extends StatelessWidget {
+  final List list;
+  const GridCards({super.key, required this.list});
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.all(8.0),
+      child: GridView.builder(
+          gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
+              crossAxisCount: 2,
+              mainAxisSpacing: 8,
+              crossAxisSpacing: 8,
+              childAspectRatio: 8 / 5),
+          itemCount: list.length,
+          itemBuilder: (context, index) {
+            return ClipRRect(
+              borderRadius: BorderRadius.circular(8),
+              child: Image.network(
+                list[index],
+                fit: BoxFit.cover,
+              ),
+            );
+          }),
+    );
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -74,7 +74,7 @@ class MyApp extends StatelessWidget {
             ),
             GoRoute(
               path: '/management',
-              pageBuilder: (context, state) => const NoTransitionPage(
+              pageBuilder: (context, state) => NoTransitionPage(
                 child: ManagementScreen(),
               ),
             ),

--- a/lib/screens/management/management_screen.dart
+++ b/lib/screens/management/management_screen.dart
@@ -1,14 +1,53 @@
+import 'package:e_meishi/components/grid_cards.dart';
 import 'package:flutter/material.dart';
 import 'package:e_meishi/components/search_field.dart';
 
 class ManagementScreen extends StatelessWidget {
-  const ManagementScreen({super.key});
+  ManagementScreen({super.key});
+
+  final List<Widget> _tabs = [
+    const Tab(icon: Icon(Icons.new_releases), text: '新着順'), // 新着順用のアイコン
+    const Tab(icon: Icon(Icons.history), text: '古い順'), // 古い順用のアイコン
+    const Tab(icon: Icon(Icons.bookmark), text: 'マーク'), // マーク用のアイコン
+  ];
+
+  final List<String> list = [
+    'https://placehold.jp/380x240.png',
+    'https://placehold.jp/360x230.png',
+    'https://placehold.jp/340x220.png',
+    'https://placehold.jp/320x210.png',
+    'https://placehold.jp/300x200.png',
+    'https://placehold.jp/280x190.png',
+    'https://placehold.jp/260x180.png',
+    'https://placehold.jp/240x170.png',
+    'https://placehold.jp/220x160.png',
+    'https://placehold.jp/200x150.png'
+  ];
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(
-        title: const SearchField(),
+    return DefaultTabController(
+      length: _tabs.length,
+      child: Scaffold(
+        appBar: AppBar(
+          title: const SearchField(),
+          bottom: TabBar(
+            tabs: _tabs,
+          ),
+        ),
+        body: TabBarView(
+          children: [
+            GridCards(
+              list: list,
+            ), // 新着順
+            GridCards(
+              list: list,
+            ), //古い順
+            GridCards(
+              list: list,
+            ), //マーク
+          ],
+        ),
       ),
     );
   }


### PR DESCRIPTION
## 概要
名刺管理ページにソートと名刺表示セクションのUIを実装した
## 対応issue
#100 

## 更新内容
- grid_cardsを作成
- management_screenのAppBarのBottomにTabBarを設置
- management_screenのBodyにTabBarViewを設置
- TabBarViewの中にgrid_cardsを設置

## テスト
1.アプリを起動
2.名刺管理ページを開く
3.TabBarのUIを確認
4.TabBarViewのUIを確認

## 注意点
元々は左にテキスト、右にソートというUIでしたが、実装の難易度とコードが複雑になる可能性を
加味して実装が簡単でコードがシンプルなタブバーを採用しました。

TabBarののtabsは固定のためリスト形式にて定義しています
TabBarViewにはgrid_cardsを設置していて、引数としてListを渡しています。
今は仮としてListを直接定義していますが、実際にはIsarと連携してリスト形式で名刺のURLを取得して渡します。

## スクリーンショット
<div style="display:flex;">
  <img src="https://github.com/user-attachments/assets/8c9388a1-dc21-4cd8-8347-08765d0e7bf9"
width="250" alt="スクリーンショット1"  />
  <img src="https://github.com/user-attachments/assets/82e80650-e4b1-4ef3-8d64-b970a33f07be"
width="250" alt="スクリーンショット1"  />
  <img src="https://github.com/user-attachments/assets/ed262815-7378-4d6c-9df3-b4ffac762b27"
width="250" alt="スクリーンショット1"  />
</div>

## その他
特になし