### PR TITLE
親子関係を見直してエラーを解消

### DIFF
--- a/lib/screens/my_page/my_page_screen.dart
+++ b/lib/screens/my_page/my_page_screen.dart
@@ -36,20 +36,16 @@ class MyPageScreen extends StatelessWidget {
               padding: EdgeInsets.symmetric(horizontal: 8, vertical: 8),
               child: Row(
                 children: [
-                  Padding(
-                    padding: EdgeInsets.symmetric(horizontal: 2),
-                    child: Expanded(
-                      child: TransitionButton(
-                        buttonText: 'お問い合わせ',
-                        transtion: '/contact',
-                        icon: Icons.outgoing_mail,
-                      ),
+                  Expanded(
+                    child: TransitionButton(
+                      buttonText: 'お問い合わせ',
+                      transtion: '/contact',
+                      icon: Icons.outgoing_mail,
                     ),
                   ),
-                  Spacer(),
-                  Padding(
-                    padding: EdgeInsets.symmetric(horizontal: 2),
-                    child: Expanded(
+                  Expanded(
+                    child: Padding(
+                      padding: EdgeInsets.symmetric(horizontal: 2),
                       child: TransitionButton(
                         buttonText: 'よくある質問',
                         transtion: '/question',


### PR DESCRIPTION
## 概要
マイページに遷移するたび出るエラーを解消

## 対応issue
#102 

## 更新内容
- Expandedの親ウィジェットとしてRowやcolumnが必須だったのでRowを親要素として整理
- テストしてPaddingが不要だったため削除
- Spacerがなくてもウィジェットが正しく描画されていたため削除

## テスト
1.アプリを起動
2.マイページに遷移
3.エラーが出ないか確認

## 注意点
この親子関係でのエラーは今後もでてきそうなので開発すると同時に必須の親子関係を理解しながら
開発していこうと思います。


## スクリーンショット
<div style="display:flex;">
  <img src="https://github.com/user-attachments/assets/fa32ba85-7535-4395-807a-2bd75e38d794"
width="500" alt="スクリーンショット1"  />
</div>

## その他
今回のエラーの原因は
Row(またはcolumn)とExpandedが直接の親子関係であることが必須だったのにも関わらず
Expandedの親がPadding,その親がRowという仕組みになってしまっていたことにあります。
