### PR TITLE
GridCardsに登録日を追加し、UIを微修正

### DIFF
--- a/lib/components/grid_cards.dart
+++ b/lib/components/grid_cards.dart
@@ -2,13 +2,18 @@ import 'package:flutter/material.dart';
 
 class GridCards extends StatelessWidget {
   final List list;
-  const GridCards({super.key, required this.list});
+  final bool isScrollable;
+  const GridCards({super.key, required this.list, this.isScrollable = true});
 
   @override
   Widget build(BuildContext context) {
     return Padding(
       padding: const EdgeInsets.all(8.0),
       child: GridView.builder(
+          shrinkWrap: isScrollable,
+          physics: isScrollable
+              ? const AlwaysScrollableScrollPhysics()
+              : const NeverScrollableScrollPhysics(),
           gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
               crossAxisCount: 2,
               mainAxisSpacing: 8,

--- a/lib/components/grid_cards.dart
+++ b/lib/components/grid_cards.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 
 class GridCards extends StatelessWidget {
-  final List list;
+  final List<Map<String, String>> list;
   final bool isScrollable;
   const GridCards({super.key, required this.list, this.isScrollable = true});
 
@@ -21,12 +21,39 @@ class GridCards extends StatelessWidget {
               childAspectRatio: 8 / 5),
           itemCount: list.length,
           itemBuilder: (context, index) {
-            return ClipRRect(
-              borderRadius: BorderRadius.circular(8),
-              child: Image.network(
-                list[index],
-                fit: BoxFit.cover,
-              ),
+            final imageUrl = list[index]['imageUrl'] ?? '';
+            final addedTime = list[index]['addedTime'] ?? '';
+
+            return Stack(
+              children: [
+                ClipRRect(
+                  borderRadius: BorderRadius.circular(8),
+                  child: Image.network(
+                    imageUrl,
+                    fit: BoxFit.cover,
+                    width: double.infinity,
+                    height: double.infinity,
+                  ),
+                ),
+                Positioned(
+                  top: 8,
+                  left: 8,
+                  child: Container(
+                    color: Colors.black.withOpacity(0.1), // 半透明の背景色
+                    child: Padding(
+                      padding: const EdgeInsets.symmetric(
+                          horizontal: 4.0, vertical: 2.0),
+                      child: Text(
+                        addedTime, // 動的に設定可能な登録日
+                        style: const TextStyle(
+                          fontSize: 10,
+                          color: Colors.white, // テキストを白色に
+                        ),
+                      ),
+                    ),
+                  ),
+                ),
+              ],
             );
           }),
     );

--- a/lib/screens/management/management_screen.dart
+++ b/lib/screens/management/management_screen.dart
@@ -11,17 +11,17 @@ class ManagementScreen extends StatelessWidget {
     const Tab(icon: Icon(Icons.bookmark), text: 'マーク'), // マーク用のアイコン
   ];
 
-  final List<String> list = [
-    'https://placehold.jp/380x240.png',
-    'https://placehold.jp/360x230.png',
-    'https://placehold.jp/340x220.png',
-    'https://placehold.jp/320x210.png',
-    'https://placehold.jp/300x200.png',
-    'https://placehold.jp/280x190.png',
-    'https://placehold.jp/260x180.png',
-    'https://placehold.jp/240x170.png',
-    'https://placehold.jp/220x160.png',
-    'https://placehold.jp/200x150.png'
+  final List<Map<String, String>> list = [
+    {'imageUrl': 'https://placehold.jp/380x240.png', 'addedTime': '2024-09-01'},
+    {'imageUrl': 'https://placehold.jp/360x230.png', 'addedTime': '2024-08-30'},
+    {'imageUrl': 'https://placehold.jp/340x220.png', 'addedTime': '2024-08-28'},
+    {'imageUrl': 'https://placehold.jp/320x210.png', 'addedTime': '2024-08-25'},
+    {'imageUrl': 'https://placehold.jp/300x200.png', 'addedTime': '2024-08-20'},
+    {'imageUrl': 'https://placehold.jp/280x190.png', 'addedTime': '2024-08-18'},
+    {'imageUrl': 'https://placehold.jp/260x180.png', 'addedTime': '2024-08-15'},
+    {'imageUrl': 'https://placehold.jp/240x170.png', 'addedTime': '2024-08-10'},
+    {'imageUrl': 'https://placehold.jp/220x160.png', 'addedTime': '2024-08-05'},
+    {'imageUrl': 'https://placehold.jp/200x150.png', 'addedTime': '2024-08-01'},
   ];
 
   @override
@@ -42,10 +42,10 @@ class ManagementScreen extends StatelessWidget {
             ), // 新着順
             GridCards(
               list: list,
-            ), //古い順
+            ), // 古い順
             GridCards(
               list: list,
-            ), //マーク
+            ), // マーク
           ],
         ),
       ),


### PR DESCRIPTION
## 概要
※このプルリクはDevelopへのマージではありません

GridCardsに登録日を追加
UIを微修正

## 対応issue
#104 

## 更新内容
- listの構造を<Map<String,String>>に修正
- それに伴ってGridCardsを使用しているファイルのリスト形式も修正
- 名刺の左上に半透明背景の登録日(AddedTime)を追加
- UIを微修正(Padding等)

## テスト
1.アプリを起動
2.GridCardsの設置してあるページへ遷移
3.UIと動作を確認

## 注意点
元々のデザインを変化しています。
GridViewの構造的にカードの上にテキストを配置するとOverFlowを起こしてしまうことが判明しました。
そのため、名刺の左上に登録日を重ねて実装しました。

リストの形式を都合上修正しましたが、実際にIsarと繋げる際にも修正する必要があると思います。
その際は都度プルリクを出します。

## スクリーンショット
<div style="display:flex;">
  <img src="https://github.com/user-attachments/assets/c81b7cc9-e81c-46ae-9093-8987c9efa9fa"
width="250" alt="スクリーンショット1"  />
</div>

## その他
特になし