### PR TITLE
自分の名刺履歴ページを作成とGridCardsの修正

### DIFF
--- a/lib/components/grid_cards.dart
+++ b/lib/components/grid_cards.dart
@@ -2,13 +2,18 @@ import 'package:flutter/material.dart';
 
 class GridCards extends StatelessWidget {
   final List list;
-  const GridCards({super.key, required this.list});
+  final bool isScrollable;
+  const GridCards({super.key, required this.list, this.isScrollable = true});
 
   @override
   Widget build(BuildContext context) {
     return Padding(
       padding: const EdgeInsets.all(8.0),
       child: GridView.builder(
+          shrinkWrap: isScrollable,
+          physics: isScrollable
+              ? const AlwaysScrollableScrollPhysics()
+              : const NeverScrollableScrollPhysics(),
           gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
               crossAxisCount: 2,
               mainAxisSpacing: 8,

--- a/lib/components/grid_cards.dart
+++ b/lib/components/grid_cards.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 
 class GridCards extends StatelessWidget {
-  final List list;
+  final List<Map<String, String>> list;
   final bool isScrollable;
   const GridCards({super.key, required this.list, this.isScrollable = true});
 
@@ -21,12 +21,39 @@ class GridCards extends StatelessWidget {
               childAspectRatio: 8 / 5),
           itemCount: list.length,
           itemBuilder: (context, index) {
-            return ClipRRect(
-              borderRadius: BorderRadius.circular(8),
-              child: Image.network(
-                list[index],
-                fit: BoxFit.cover,
-              ),
+            final imageUrl = list[index]['imageUrl'] ?? '';
+            final addedTime = list[index]['addedTime'] ?? '';
+
+            return Stack(
+              children: [
+                ClipRRect(
+                  borderRadius: BorderRadius.circular(8),
+                  child: Image.network(
+                    imageUrl,
+                    fit: BoxFit.cover,
+                    width: double.infinity,
+                    height: double.infinity,
+                  ),
+                ),
+                Positioned(
+                  top: 8,
+                  left: 8,
+                  child: Container(
+                    color: Colors.black.withOpacity(0.1), // 半透明の背景色
+                    child: Padding(
+                      padding: const EdgeInsets.symmetric(
+                          horizontal: 4.0, vertical: 2.0),
+                      child: Text(
+                        addedTime, // 動的に設定可能な登録日
+                        style: const TextStyle(
+                          fontSize: 10,
+                          color: Colors.white, // テキストを白色に
+                        ),
+                      ),
+                    ),
+                  ),
+                ),
+              ],
             );
           }),
     );

--- a/lib/components/grid_cards.dart
+++ b/lib/components/grid_cards.dart
@@ -10,7 +10,7 @@ class GridCards extends StatelessWidget {
     return Padding(
       padding: const EdgeInsets.all(8.0),
       child: GridView.builder(
-          shrinkWrap: isScrollable,
+          shrinkWrap: !isScrollable,
           physics: isScrollable
               ? const AlwaysScrollableScrollPhysics()
               : const NeverScrollableScrollPhysics(),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -87,7 +87,7 @@ class MyApp extends StatelessWidget {
               routes: <GoRoute>[
                 GoRoute(
                   path: 'history',
-                  pageBuilder: (context, state) => const NoTransitionPage(
+                  pageBuilder: (context, state) => NoTransitionPage(
                     child: HistoryScreen(),
                   ),
                 ),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,6 +1,7 @@
 import 'package:e_meishi/models/meishi.dart';
 import 'package:e_meishi/screens/add/add_meishi.dart';
 import 'package:e_meishi/screens/add/display_picture_screen.dart';
+import 'package:e_meishi/screens/history/history_screen.dart';
 import 'screens/management/management_screen.dart';
 import 'screens/main/main_screen.dart';
 import 'package:flutter/material.dart';
@@ -83,6 +84,14 @@ class MyApp extends StatelessWidget {
               pageBuilder: (context, state) => const NoTransitionPage(
                 child: MyPageScreen(),
               ),
+              routes: <GoRoute>[
+                GoRoute(
+                  path: 'history',
+                  pageBuilder: (context, state) => const NoTransitionPage(
+                    child: HistoryScreen(),
+                  ),
+                ),
+              ],
             ),
           ],
         ),

--- a/lib/screens/history/history_screen.dart
+++ b/lib/screens/history/history_screen.dart
@@ -1,0 +1,10 @@
+import 'package:flutter/material.dart';
+
+class HistoryScreen extends StatelessWidget {
+  const HistoryScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const Placeholder();
+  }
+}

--- a/lib/screens/history/history_screen.dart
+++ b/lib/screens/history/history_screen.dart
@@ -5,31 +5,32 @@ import 'package:flutter/material.dart';
 class HistoryScreen extends StatelessWidget {
   HistoryScreen({super.key});
 
-  final List<String> list = [
-    'https://placehold.jp/380x240.png',
-    'https://placehold.jp/360x230.png',
-    'https://placehold.jp/340x220.png',
-    'https://placehold.jp/320x210.png',
-    'https://placehold.jp/300x200.png',
-    'https://placehold.jp/280x190.png',
-    'https://placehold.jp/260x180.png',
-    'https://placehold.jp/240x170.png',
-    'https://placehold.jp/220x160.png',
-    'https://placehold.jp/200x150.png'
+  final List<Map<String, String>> list = [
+    {'imageUrl': 'https://placehold.jp/380x240.png', 'addedTime': '2024-09-01'},
+    {'imageUrl': 'https://placehold.jp/360x230.png', 'addedTime': '2024-08-30'},
+    {'imageUrl': 'https://placehold.jp/340x220.png', 'addedTime': '2024-08-28'},
+    {'imageUrl': 'https://placehold.jp/320x210.png', 'addedTime': '2024-08-25'},
+    {'imageUrl': 'https://placehold.jp/300x200.png', 'addedTime': '2024-08-20'},
+    {'imageUrl': 'https://placehold.jp/280x190.png', 'addedTime': '2024-08-18'},
+    {'imageUrl': 'https://placehold.jp/260x180.png', 'addedTime': '2024-08-15'},
+    {'imageUrl': 'https://placehold.jp/240x170.png', 'addedTime': '2024-08-10'},
+    {'imageUrl': 'https://placehold.jp/220x160.png', 'addedTime': '2024-08-05'},
+    {'imageUrl': 'https://placehold.jp/200x150.png', 'addedTime': '2024-08-01'},
   ];
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
         title: const Text('名刺履歴'),
       ),
-      body: const Padding(
-        padding: EdgeInsets.all(8.0),
+      body: Padding(
+        padding: const EdgeInsets.all(8.0),
         child: SingleChildScrollView(
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
-              FittedBox(
+              const FittedBox(
                 child: Text(
                   '現在の名刺',
                   style: TextStyle(
@@ -39,13 +40,26 @@ class HistoryScreen extends StatelessWidget {
                   ),
                 ),
               ),
-              BigMeishiView(meishiId: 1),
-              SizedBox(height: 8.0), // Dividerとのスペースを作る
-              Divider(
+              const BigMeishiView(meishiId: 1),
+              const SizedBox(height: 8.0), // Dividerとのスペースを作る
+              const Divider(
                 thickness: 1,
                 color: Colors.grey,
               ),
-
+              const FittedBox(
+                child: Text(
+                  '過去の名刺',
+                  style: TextStyle(
+                    fontWeight: FontWeight.bold,
+                    fontSize: 16,
+                    fontFamily: 'Hiragino Sans',
+                  ),
+                ),
+              ),
+              GridCards(
+                list: list,
+                isScrollable: false,
+              )
             ],
           ),
         ),

--- a/lib/screens/history/history_screen.dart
+++ b/lib/screens/history/history_screen.dart
@@ -30,13 +30,16 @@ class HistoryScreen extends StatelessWidget {
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
-              const FittedBox(
-                child: Text(
-                  '現在の名刺',
-                  style: TextStyle(
-                    fontWeight: FontWeight.bold,
-                    fontSize: 16,
-                    fontFamily: 'Hiragino Sans',
+              const Padding(
+                padding: EdgeInsets.all(8.0),
+                child: FittedBox(
+                  child: Text(
+                    '現在の名刺',
+                    style: TextStyle(
+                      fontWeight: FontWeight.bold,
+                      fontSize: 16,
+                      fontFamily: 'Hiragino Sans',
+                    ),
                   ),
                 ),
               ),
@@ -46,13 +49,16 @@ class HistoryScreen extends StatelessWidget {
                 thickness: 1,
                 color: Colors.grey,
               ),
-              const FittedBox(
-                child: Text(
-                  '過去の名刺',
-                  style: TextStyle(
-                    fontWeight: FontWeight.bold,
-                    fontSize: 16,
-                    fontFamily: 'Hiragino Sans',
+              const Padding(
+                padding: EdgeInsets.all(8.0),
+                child: FittedBox(
+                  child: Text(
+                    '過去の名刺',
+                    style: TextStyle(
+                      fontWeight: FontWeight.bold,
+                      fontSize: 16,
+                      fontFamily: 'Hiragino Sans',
+                    ),
                   ),
                 ),
               ),

--- a/lib/screens/history/history_screen.dart
+++ b/lib/screens/history/history_screen.dart
@@ -1,10 +1,55 @@
+import 'package:e_meishi/components/big_meishi_view.dart';
+import 'package:e_meishi/components/grid_cards.dart';
 import 'package:flutter/material.dart';
 
 class HistoryScreen extends StatelessWidget {
-  const HistoryScreen({super.key});
+  HistoryScreen({super.key});
 
+  final List<String> list = [
+    'https://placehold.jp/380x240.png',
+    'https://placehold.jp/360x230.png',
+    'https://placehold.jp/340x220.png',
+    'https://placehold.jp/320x210.png',
+    'https://placehold.jp/300x200.png',
+    'https://placehold.jp/280x190.png',
+    'https://placehold.jp/260x180.png',
+    'https://placehold.jp/240x170.png',
+    'https://placehold.jp/220x160.png',
+    'https://placehold.jp/200x150.png'
+  ];
   @override
   Widget build(BuildContext context) {
-    return const Placeholder();
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('名刺履歴'),
+      ),
+      body: const Padding(
+        padding: EdgeInsets.all(8.0),
+        child: SingleChildScrollView(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              FittedBox(
+                child: Text(
+                  '現在の名刺',
+                  style: TextStyle(
+                    fontWeight: FontWeight.bold,
+                    fontSize: 16,
+                    fontFamily: 'Hiragino Sans',
+                  ),
+                ),
+              ),
+              BigMeishiView(meishiId: 1),
+              SizedBox(height: 8.0), // Dividerとのスペースを作る
+              Divider(
+                thickness: 1,
+                color: Colors.grey,
+              ),
+
+            ],
+          ),
+        ),
+      ),
+    );
   }
 }

--- a/lib/screens/management/management_screen.dart
+++ b/lib/screens/management/management_screen.dart
@@ -11,17 +11,17 @@ class ManagementScreen extends StatelessWidget {
     const Tab(icon: Icon(Icons.bookmark), text: 'マーク'), // マーク用のアイコン
   ];
 
-  final List<String> list = [
-    'https://placehold.jp/380x240.png',
-    'https://placehold.jp/360x230.png',
-    'https://placehold.jp/340x220.png',
-    'https://placehold.jp/320x210.png',
-    'https://placehold.jp/300x200.png',
-    'https://placehold.jp/280x190.png',
-    'https://placehold.jp/260x180.png',
-    'https://placehold.jp/240x170.png',
-    'https://placehold.jp/220x160.png',
-    'https://placehold.jp/200x150.png'
+  final List<Map<String, String>> list = [
+    {'imageUrl': 'https://placehold.jp/380x240.png', 'addedTime': '2024-09-01'},
+    {'imageUrl': 'https://placehold.jp/360x230.png', 'addedTime': '2024-08-30'},
+    {'imageUrl': 'https://placehold.jp/340x220.png', 'addedTime': '2024-08-28'},
+    {'imageUrl': 'https://placehold.jp/320x210.png', 'addedTime': '2024-08-25'},
+    {'imageUrl': 'https://placehold.jp/300x200.png', 'addedTime': '2024-08-20'},
+    {'imageUrl': 'https://placehold.jp/280x190.png', 'addedTime': '2024-08-18'},
+    {'imageUrl': 'https://placehold.jp/260x180.png', 'addedTime': '2024-08-15'},
+    {'imageUrl': 'https://placehold.jp/240x170.png', 'addedTime': '2024-08-10'},
+    {'imageUrl': 'https://placehold.jp/220x160.png', 'addedTime': '2024-08-05'},
+    {'imageUrl': 'https://placehold.jp/200x150.png', 'addedTime': '2024-08-01'},
   ];
 
   @override
@@ -42,10 +42,10 @@ class ManagementScreen extends StatelessWidget {
             ), // 新着順
             GridCards(
               list: list,
-            ), //古い順
+            ), // 古い順
             GridCards(
               list: list,
-            ), //マーク
+            ), // マーク
           ],
         ),
       ),

--- a/lib/screens/my_page/my_page_screen.dart
+++ b/lib/screens/my_page/my_page_screen.dart
@@ -27,7 +27,7 @@ class MyPageScreen extends StatelessWidget {
               padding: EdgeInsets.all(8.0),
               child: TransitionButton(
                 buttonText: '過去の名刺を見る',
-                transtion: '/history',
+                transtion: '/mypage/history',
                 icon: Icons.history,
               ),
             ),


### PR DESCRIPTION
## 概要
自分の名刺履歴を一覧表示するページを作成
GridCardsに登録日を追加とその他修正

## プルリクについて
このプルリクは二つのプルリクがマージされています
#106 #105 

## 対応issue
#61 

## 更新内容
- main.dartにて/historyのルートを作成した
- mypageから遷移するためのパスを修正
- 現在の名刺を表示するためBigMeishiViewを使用
- 過去の名刺を表示するためにGridCardコンポーネントを使用
- GridCardsに渡すリスト構造を変更
- GridCardsに登録日を追加
- GridCardsをスクロール可能にするか否かのパラメータを追加

## テスト
1.アプリを起動
2.マイページに移動し名刺履歴ページへ遷移
3.UIを確認

## 注意点
UIが元々と変化しています。
元々はカードの上に薄い色で登録日時を設置する予定のところ、カードの左上に重ねて表示するようにしました。
GridViewの構造上カードの外側に配置するとBottomFlowが発生してしまってエラーになったためです。

## スクリーンショット
<div style="display:flex;">
  <img src="https://github.com/user-attachments/assets/edca58ac-46df-4db2-8eaf-d8619e1334da"
width="300" alt="スクリーンショット1"  />
</div>

## その他
特になし