### PR TITLE
名刺詳細ページのルーティング

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,6 +1,7 @@
 import 'package:e_meishi/models/meishi.dart';
 import 'package:e_meishi/screens/add/add_meishi.dart';
 import 'package:e_meishi/screens/add/display_picture_screen.dart';
+import 'package:e_meishi/screens/detail/detail_screen.dart';
 import 'package:e_meishi/screens/history/history_screen.dart';
 import 'screens/management/management_screen.dart';
 import 'screens/main/main_screen.dart';
@@ -111,6 +112,12 @@ class MyApp extends StatelessWidget {
               imagePath: imagePath,
               isar: isar,
             );
+          },
+        ),
+        GoRoute(
+          path: '/detail',
+          builder: (BuildContext context, GoRouterState state) {
+            return const DetailScreen();
           },
         ),
       ],

--- a/lib/screens/detail/detail_screen.dart
+++ b/lib/screens/detail/detail_screen.dart
@@ -1,0 +1,10 @@
+import 'package:flutter/material.dart';
+
+class DetailScreen extends StatelessWidget {
+  const DetailScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const Placeholder();
+  }
+}


### PR DESCRIPTION
## 概要
※このプルリクはDevelopへのマージではありません

名刺詳細ページのルーティング

## 対応issue
#110 

## 更新内容
- main.dartにdetailのルートを作成
- detail/detail_screen.dartを作成(中身はstatelesswidgetの金型)

## テスト
特になし

## 注意点
このプルリクからマージ戦略を変更します
いままではできた部品をそのままdevelopブランチへマージしていましたが、
これからはページごとにマージしてまとめてからdevelopブランチにマージしようと思います。

## スクリーンショット
変化がないためなし

## その他
特になし