### PR TITLE
名刺詳細ページにBigMeishiViewを設置

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -117,7 +117,9 @@ class MyApp extends StatelessWidget {
         GoRoute(
           path: '/detail',
           builder: (BuildContext context, GoRouterState state) {
-            return const DetailScreen();
+            return const DetailScreen(
+              meishiId: 1,
+            );
           },
         ),
       ],

--- a/lib/screens/detail/detail_screen.dart
+++ b/lib/screens/detail/detail_screen.dart
@@ -8,6 +8,10 @@ class DetailScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return BigMeishiView(meishiId: meishiId);
+    return Scaffold(
+        appBar: AppBar(
+          title: Text(('名刺詳細ページ')),
+        ),
+        body: BigMeishiView(meishiId: meishiId));
   }
 }

--- a/lib/screens/detail/detail_screen.dart
+++ b/lib/screens/detail/detail_screen.dart
@@ -1,10 +1,13 @@
+import 'package:e_meishi/components/big_meishi_view.dart';
 import 'package:flutter/material.dart';
 
 class DetailScreen extends StatelessWidget {
-  const DetailScreen({super.key});
+  final int meishiId;
+
+  const DetailScreen({super.key, required this.meishiId});
 
   @override
   Widget build(BuildContext context) {
-    return const Placeholder();
+    return BigMeishiView(meishiId: meishiId);
   }
 }


### PR DESCRIPTION
## 概要
名刺詳細ページにBigMeishiViewを設置した

## プルリクについて
このプルリクはfeature/meishi-detail-pageへのマージです

## 対応issue
#109 

## 更新内容
- detail_screen.dartを作成
- ScffoldやAppBarを追加
- BigMeishiViewをdetail_screen.dartに設置

## テスト
1.アプリを起動
2./detailに遷移
3.UIを確認

## 注意点
特になし

## スクリーンショット
<div style="display:flex;">
  <img src="https://github.com/user-attachments/assets/e27dfb9a-e8a7-490f-a9d9-aed91fe27871"
width="300" alt="スクリーンショット1"  />
</div>

## その他
特になし