### PR TITLE
1行記述式コンポーネントを作成

### DIFF
--- a/lib/components/single_line_description.dart
+++ b/lib/components/single_line_description.dart
@@ -1,0 +1,21 @@
+import 'package:flutter/material.dart';
+
+class OneLineDescription extends StatelessWidget {
+  final String hintText;
+  const OneLineDescription({super.key, required this.hintText});
+
+  @override
+  Widget build(BuildContext context) {
+    return TextField(
+      decoration: InputDecoration(
+          hintText: hintText,
+          filled: true,
+          fillColor: Colors.grey[200],
+          border: OutlineInputBorder(
+            borderSide: BorderSide.none,
+            borderRadius: BorderRadius.circular(8.0),
+          ),
+          isDense: true),
+    );
+  }
+}

--- a/lib/screens/detail/detail_screen.dart
+++ b/lib/screens/detail/detail_screen.dart
@@ -1,4 +1,5 @@
 import 'package:e_meishi/components/big_meishi_view.dart';
+import 'package:e_meishi/components/single_line_description.dart';
 import 'package:flutter/material.dart';
 
 class DetailScreen extends StatelessWidget {
@@ -10,8 +11,16 @@ class DetailScreen extends StatelessWidget {
   Widget build(BuildContext context) {
     return Scaffold(
         appBar: AppBar(
-          title: Text(('名刺詳細ページ')),
+          title: const Text(('名刺詳細ページ')),
         ),
-        body: BigMeishiView(meishiId: meishiId));
+        body: Column(
+          children: [
+            BigMeishiView(meishiId: meishiId),
+            const Padding(
+              padding: EdgeInsets.all(8.0),
+              child: OneLineDescription(hintText: '名前'),
+            )
+          ],
+        ));
   }
 }


### PR DESCRIPTION
## 概要
名刺詳細ページに使用する1行記述式コンポーネントを作成した

## プルリクについて
このプルリクはfeature/meishi-detail-pageへのマージです

## 対応issue
#112 

## 更新内容
- single_line_description.dartを作成
- detail_screen.dartにsingle_line_descriptionを設置

## テスト
1.アプリを起動
2./detailに遷移
3.UIを確認

## 注意点
特になし

## スクリーンショット
<div style="display:flex;">
  <img src="https://github.com/user-attachments/assets/a8b9bcc8-0c9a-4da1-af9a-66888952df17"
width="300" alt="スクリーンショット1"  />
</div>

## その他
特になし