### PR TITLE
長文記述式コンポーネントを作成

### DIFF
--- a/lib/components/long_description.dart
+++ b/lib/components/long_description.dart
@@ -1,0 +1,24 @@
+import 'package:flutter/material.dart';
+
+class LongDescription extends StatelessWidget {
+  final String hintText;
+  const LongDescription({super.key, required this.hintText});
+
+  @override
+  Widget build(BuildContext context) {
+    return TextField(
+        decoration: InputDecoration(
+          hintText: hintText,
+          filled: true,
+          fillColor: Colors.grey[200],
+          border: OutlineInputBorder(
+            borderSide: BorderSide.none,
+            borderRadius: BorderRadius.circular(8.0),
+          ),
+          isDense: true,
+        ),
+        minLines: 8,
+        maxLines: null,
+        keyboardType: TextInputType.multiline);
+  }
+}

--- a/lib/components/long_description.dart
+++ b/lib/components/long_description.dart
@@ -17,7 +17,7 @@ class LongDescription extends StatelessWidget {
           ),
           isDense: true,
         ),
-        minLines: 8,
+        minLines: 5,
         maxLines: null,
         keyboardType: TextInputType.multiline);
   }

--- a/lib/screens/detail/detail_screen.dart
+++ b/lib/screens/detail/detail_screen.dart
@@ -1,5 +1,6 @@
 import 'package:e_meishi/components/big_meishi_view.dart';
 import 'package:e_meishi/components/single_line_description.dart';
+import 'package:e_meishi/components/long_description.dart';
 import 'package:flutter/material.dart';
 
 class DetailScreen extends StatelessWidget {
@@ -13,14 +14,21 @@ class DetailScreen extends StatelessWidget {
         appBar: AppBar(
           title: const Text(('名刺詳細ページ')),
         ),
-        body: Column(
-          children: [
-            BigMeishiView(meishiId: meishiId),
-            const Padding(
-              padding: EdgeInsets.all(8.0),
-              child: OneLineDescription(hintText: '名前'),
-            )
-          ],
+        body: SingleChildScrollView(
+          child: Column(
+            children: [
+              BigMeishiView(meishiId: meishiId),
+              const Padding(
+                padding: EdgeInsets.all(8.0),
+                child: Column(
+                  children: [
+                    OneLineDescription(hintText: '名前'),
+                    LongDescription(hintText: '名刺の説明やメモなど'),
+                  ],
+                ),
+              )
+            ],
+          ),
         ));
   }
 }


### PR DESCRIPTION
## 概要
名刺詳細ページに使用する長文記述式コンポーネントを作成した

## プルリクについて
このプルリクはfeature/meishi-detail-pageへのマージです

## 対応issue
#113  

## 更新内容
- long_description.dartを作成
- detail_screen.dartにlong_descriptionを設置

## テスト
1.アプリを起動
2./detailに遷移
3.UIを確認

## 注意点
現時点では名刺詳細画面に設置しただけでスタイリングなどはされていません。
このブランチではコンポーネントを作成するのが目的のため、スタイリングなどは別のブランチにて作業します。

## スクリーンショット
<div style="display:flex;">
  <img src="https://github.com/user-attachments/assets/27650db5-e990-46b3-9cea-5be0d7036c3c"
width="300" alt="スクリーンショット1"  />
  <img src="https://github.com/user-attachments/assets/0c0bc6a0-348d-4d13-8be2-c0b34bccfcf0"
width="300" alt="スクリーンショット2"  />
</div>

## その他
特になし