### PR TITLE
名刺詳細ページのスタイリング

### DIFF
--- a/lib/components/long_description.dart
+++ b/lib/components/long_description.dart
@@ -8,20 +8,31 @@ class LongDescription extends StatelessWidget {
   Widget build(BuildContext context) {
     return Padding(
       padding: const EdgeInsets.symmetric(vertical: 8.0),
-      child: TextField(
-          decoration: InputDecoration(
-            hintText: hintText,
-            filled: true,
-            fillColor: Colors.grey[200],
-            border: OutlineInputBorder(
-              borderSide: BorderSide.none,
-              borderRadius: BorderRadius.circular(8.0),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 8.0, vertical: 4.0),
+            child: Text(
+              hintText,
+              style: const TextStyle(fontSize: 14, fontWeight: FontWeight.bold),
             ),
-            isDense: true,
           ),
-          minLines: 5,
-          maxLines: null,
-          keyboardType: TextInputType.multiline),
+          TextField(
+              decoration: InputDecoration(
+                filled: true,
+                fillColor: Colors.grey[200],
+                border: OutlineInputBorder(
+                  borderSide: BorderSide.none,
+                  borderRadius: BorderRadius.circular(8.0),
+                ),
+                isDense: true,
+              ),
+              minLines: 5,
+              maxLines: null,
+              keyboardType: TextInputType.multiline),
+        ],
+      ),
     );
   }
 }

--- a/lib/components/long_description.dart
+++ b/lib/components/long_description.dart
@@ -6,19 +6,22 @@ class LongDescription extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return TextField(
-        decoration: InputDecoration(
-          hintText: hintText,
-          filled: true,
-          fillColor: Colors.grey[200],
-          border: OutlineInputBorder(
-            borderSide: BorderSide.none,
-            borderRadius: BorderRadius.circular(8.0),
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 8.0),
+      child: TextField(
+          decoration: InputDecoration(
+            hintText: hintText,
+            filled: true,
+            fillColor: Colors.grey[200],
+            border: OutlineInputBorder(
+              borderSide: BorderSide.none,
+              borderRadius: BorderRadius.circular(8.0),
+            ),
+            isDense: true,
           ),
-          isDense: true,
-        ),
-        minLines: 5,
-        maxLines: null,
-        keyboardType: TextInputType.multiline);
+          minLines: 5,
+          maxLines: null,
+          keyboardType: TextInputType.multiline),
+    );
   }
 }

--- a/lib/components/single_line_description.dart
+++ b/lib/components/single_line_description.dart
@@ -6,16 +6,19 @@ class OneLineDescription extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return TextField(
-      decoration: InputDecoration(
-          hintText: hintText,
-          filled: true,
-          fillColor: Colors.grey[200],
-          border: OutlineInputBorder(
-            borderSide: BorderSide.none,
-            borderRadius: BorderRadius.circular(8.0),
-          ),
-          isDense: true),
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 8.0),
+      child: TextField(
+        decoration: InputDecoration(
+            hintText: hintText,
+            filled: true,
+            fillColor: Colors.grey[200],
+            border: OutlineInputBorder(
+              borderSide: BorderSide.none,
+              borderRadius: BorderRadius.circular(8.0),
+            ),
+            isDense: true),
+      ),
     );
   }
 }

--- a/lib/components/single_line_description.dart
+++ b/lib/components/single_line_description.dart
@@ -7,17 +7,28 @@ class OneLineDescription extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Padding(
-      padding: const EdgeInsets.symmetric(vertical: 8.0),
-      child: TextField(
-        decoration: InputDecoration(
-            hintText: hintText,
-            filled: true,
-            fillColor: Colors.grey[200],
-            border: OutlineInputBorder(
-              borderSide: BorderSide.none,
-              borderRadius: BorderRadius.circular(8.0),
+      padding: const EdgeInsets.symmetric(vertical: 4.0),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 8.0, vertical: 4.0),
+            child: Text(
+              hintText,
+              style: const TextStyle(fontSize: 14, fontWeight: FontWeight.bold),
             ),
-            isDense: true),
+          ),
+          TextField(
+            decoration: InputDecoration(
+                filled: true,
+                fillColor: Colors.grey[200],
+                border: OutlineInputBorder(
+                  borderSide: BorderSide.none,
+                  borderRadius: BorderRadius.circular(8.0),
+                ),
+                isDense: true),
+          ),
+        ],
       ),
     );
   }

--- a/lib/screens/detail/detail_screen.dart
+++ b/lib/screens/detail/detail_screen.dart
@@ -23,6 +23,16 @@ class DetailScreen extends StatelessWidget {
                 child: Column(
                   children: [
                     OneLineDescription(hintText: '名前'),
+                    Row(
+                      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                      children: [
+                        Expanded(child: OneLineDescription(hintText: '性別')),
+                        SizedBox(width: 8),
+                        Expanded(child: OneLineDescription(hintText: '年齢')),
+                      ],
+                    ),
+                    OneLineDescription(hintText: '所属'),
+                    OneLineDescription(hintText: '電話番号'),
                     LongDescription(hintText: '名刺の説明やメモなど'),
                   ],
                 ),

--- a/lib/screens/detail/detail_screen.dart
+++ b/lib/screens/detail/detail_screen.dart
@@ -33,7 +33,7 @@ class DetailScreen extends StatelessWidget {
                     ),
                     OneLineDescription(hintText: '所属'),
                     OneLineDescription(hintText: '電話番号'),
-                    LongDescription(hintText: '名刺の説明やメモなど'),
+                    LongDescription(hintText: 'メモなど'),
                   ],
                 ),
               )


### PR DESCRIPTION
## 概要
名刺詳細ページに設置するコンポーネントと全体のスタイリング

## プルリクについて
このプルリクはfeature/meishi-detail-pageへのマージです

## 対応issue
#115 

## 更新内容
- long_description.dartのPaddingを調整
- long_description.dartのTexFieldの左上にhintTextを設置
- long_description.dartのTextFiledの中にhintTextを削除
- single_line_descriptionのPaddingを調整
- single_line_descriptionのTexFieldの左上にhintTextを設置
- single_line_descriptionのTextFiledの中にhintTextを削除
- detail_page全体のPaddingを調整
- detail_pageに二つのコンポーネントをレイアウト通りに設置

## テスト
1.アプリを起動
2./detailに遷移
3.UIを確認

## 注意点
元々は均等な感覚をSpacerで実現しようとしていましたが、singleChildScrollViewは無限の高さになってしまうためSpacerは使えず。
そのため、コンポーネント自体にPaddingを設置して実装しました。

## スクリーンショット
<div style="display:flex;">
  <img src="https://github.com/user-attachments/assets/c09fc5da-1bcd-431d-a1e3-b059d47a40e5"
width="300" alt="スクリーンショット1"  />
</div>

## その他
特になし