### PR TITLE
名刺詳細ページUIとコンポーネントを作成

### DIFF
--- a/lib/components/long_description.dart
+++ b/lib/components/long_description.dart
@@ -1,0 +1,24 @@
+import 'package:flutter/material.dart';
+
+class LongDescription extends StatelessWidget {
+  final String hintText;
+  const LongDescription({super.key, required this.hintText});
+
+  @override
+  Widget build(BuildContext context) {
+    return TextField(
+        decoration: InputDecoration(
+          hintText: hintText,
+          filled: true,
+          fillColor: Colors.grey[200],
+          border: OutlineInputBorder(
+            borderSide: BorderSide.none,
+            borderRadius: BorderRadius.circular(8.0),
+          ),
+          isDense: true,
+        ),
+        minLines: 8,
+        maxLines: null,
+        keyboardType: TextInputType.multiline);
+  }
+}

--- a/lib/components/long_description.dart
+++ b/lib/components/long_description.dart
@@ -8,20 +8,31 @@ class LongDescription extends StatelessWidget {
   Widget build(BuildContext context) {
     return Padding(
       padding: const EdgeInsets.symmetric(vertical: 8.0),
-      child: TextField(
-          decoration: InputDecoration(
-            hintText: hintText,
-            filled: true,
-            fillColor: Colors.grey[200],
-            border: OutlineInputBorder(
-              borderSide: BorderSide.none,
-              borderRadius: BorderRadius.circular(8.0),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 8.0, vertical: 4.0),
+            child: Text(
+              hintText,
+              style: const TextStyle(fontSize: 14, fontWeight: FontWeight.bold),
             ),
-            isDense: true,
           ),
-          minLines: 5,
-          maxLines: null,
-          keyboardType: TextInputType.multiline),
+          TextField(
+              decoration: InputDecoration(
+                filled: true,
+                fillColor: Colors.grey[200],
+                border: OutlineInputBorder(
+                  borderSide: BorderSide.none,
+                  borderRadius: BorderRadius.circular(8.0),
+                ),
+                isDense: true,
+              ),
+              minLines: 5,
+              maxLines: null,
+              keyboardType: TextInputType.multiline),
+        ],
+      ),
     );
   }
 }

--- a/lib/components/long_description.dart
+++ b/lib/components/long_description.dart
@@ -17,7 +17,7 @@ class LongDescription extends StatelessWidget {
           ),
           isDense: true,
         ),
-        minLines: 8,
+        minLines: 5,
         maxLines: null,
         keyboardType: TextInputType.multiline);
   }

--- a/lib/components/long_description.dart
+++ b/lib/components/long_description.dart
@@ -6,19 +6,22 @@ class LongDescription extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return TextField(
-        decoration: InputDecoration(
-          hintText: hintText,
-          filled: true,
-          fillColor: Colors.grey[200],
-          border: OutlineInputBorder(
-            borderSide: BorderSide.none,
-            borderRadius: BorderRadius.circular(8.0),
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 8.0),
+      child: TextField(
+          decoration: InputDecoration(
+            hintText: hintText,
+            filled: true,
+            fillColor: Colors.grey[200],
+            border: OutlineInputBorder(
+              borderSide: BorderSide.none,
+              borderRadius: BorderRadius.circular(8.0),
+            ),
+            isDense: true,
           ),
-          isDense: true,
-        ),
-        minLines: 5,
-        maxLines: null,
-        keyboardType: TextInputType.multiline);
+          minLines: 5,
+          maxLines: null,
+          keyboardType: TextInputType.multiline),
+    );
   }
 }

--- a/lib/components/single_line_description.dart
+++ b/lib/components/single_line_description.dart
@@ -6,16 +6,19 @@ class OneLineDescription extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return TextField(
-      decoration: InputDecoration(
-          hintText: hintText,
-          filled: true,
-          fillColor: Colors.grey[200],
-          border: OutlineInputBorder(
-            borderSide: BorderSide.none,
-            borderRadius: BorderRadius.circular(8.0),
-          ),
-          isDense: true),
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 8.0),
+      child: TextField(
+        decoration: InputDecoration(
+            hintText: hintText,
+            filled: true,
+            fillColor: Colors.grey[200],
+            border: OutlineInputBorder(
+              borderSide: BorderSide.none,
+              borderRadius: BorderRadius.circular(8.0),
+            ),
+            isDense: true),
+      ),
     );
   }
 }

--- a/lib/components/single_line_description.dart
+++ b/lib/components/single_line_description.dart
@@ -7,17 +7,28 @@ class OneLineDescription extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Padding(
-      padding: const EdgeInsets.symmetric(vertical: 8.0),
-      child: TextField(
-        decoration: InputDecoration(
-            hintText: hintText,
-            filled: true,
-            fillColor: Colors.grey[200],
-            border: OutlineInputBorder(
-              borderSide: BorderSide.none,
-              borderRadius: BorderRadius.circular(8.0),
+      padding: const EdgeInsets.symmetric(vertical: 4.0),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 8.0, vertical: 4.0),
+            child: Text(
+              hintText,
+              style: const TextStyle(fontSize: 14, fontWeight: FontWeight.bold),
             ),
-            isDense: true),
+          ),
+          TextField(
+            decoration: InputDecoration(
+                filled: true,
+                fillColor: Colors.grey[200],
+                border: OutlineInputBorder(
+                  borderSide: BorderSide.none,
+                  borderRadius: BorderRadius.circular(8.0),
+                ),
+                isDense: true),
+          ),
+        ],
       ),
     );
   }

--- a/lib/components/single_line_description.dart
+++ b/lib/components/single_line_description.dart
@@ -1,0 +1,21 @@
+import 'package:flutter/material.dart';
+
+class OneLineDescription extends StatelessWidget {
+  final String hintText;
+  const OneLineDescription({super.key, required this.hintText});
+
+  @override
+  Widget build(BuildContext context) {
+    return TextField(
+      decoration: InputDecoration(
+          hintText: hintText,
+          filled: true,
+          fillColor: Colors.grey[200],
+          border: OutlineInputBorder(
+            borderSide: BorderSide.none,
+            borderRadius: BorderRadius.circular(8.0),
+          ),
+          isDense: true),
+    );
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -117,7 +117,9 @@ class MyApp extends StatelessWidget {
         GoRoute(
           path: '/detail',
           builder: (BuildContext context, GoRouterState state) {
-            return const DetailScreen();
+            return const DetailScreen(
+              meishiId: 1,
+            );
           },
         ),
       ],

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,6 +1,7 @@
 import 'package:e_meishi/models/meishi.dart';
 import 'package:e_meishi/screens/add/add_meishi.dart';
 import 'package:e_meishi/screens/add/display_picture_screen.dart';
+import 'package:e_meishi/screens/detail/detail_screen.dart';
 import 'package:e_meishi/screens/history/history_screen.dart';
 import 'screens/management/management_screen.dart';
 import 'screens/main/main_screen.dart';
@@ -111,6 +112,12 @@ class MyApp extends StatelessWidget {
               imagePath: imagePath,
               isar: isar,
             );
+          },
+        ),
+        GoRoute(
+          path: '/detail',
+          builder: (BuildContext context, GoRouterState state) {
+            return const DetailScreen();
           },
         ),
       ],

--- a/lib/screens/detail/detail_screen.dart
+++ b/lib/screens/detail/detail_screen.dart
@@ -1,0 +1,10 @@
+import 'package:flutter/material.dart';
+
+class DetailScreen extends StatelessWidget {
+  const DetailScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const Placeholder();
+  }
+}

--- a/lib/screens/detail/detail_screen.dart
+++ b/lib/screens/detail/detail_screen.dart
@@ -8,6 +8,10 @@ class DetailScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return BigMeishiView(meishiId: meishiId);
+    return Scaffold(
+        appBar: AppBar(
+          title: Text(('名刺詳細ページ')),
+        ),
+        body: BigMeishiView(meishiId: meishiId));
   }
 }

--- a/lib/screens/detail/detail_screen.dart
+++ b/lib/screens/detail/detail_screen.dart
@@ -23,6 +23,16 @@ class DetailScreen extends StatelessWidget {
                 child: Column(
                   children: [
                     OneLineDescription(hintText: '名前'),
+                    Row(
+                      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                      children: [
+                        Expanded(child: OneLineDescription(hintText: '性別')),
+                        SizedBox(width: 8),
+                        Expanded(child: OneLineDescription(hintText: '年齢')),
+                      ],
+                    ),
+                    OneLineDescription(hintText: '所属'),
+                    OneLineDescription(hintText: '電話番号'),
                     LongDescription(hintText: '名刺の説明やメモなど'),
                   ],
                 ),

--- a/lib/screens/detail/detail_screen.dart
+++ b/lib/screens/detail/detail_screen.dart
@@ -1,10 +1,13 @@
+import 'package:e_meishi/components/big_meishi_view.dart';
 import 'package:flutter/material.dart';
 
 class DetailScreen extends StatelessWidget {
-  const DetailScreen({super.key});
+  final int meishiId;
+
+  const DetailScreen({super.key, required this.meishiId});
 
   @override
   Widget build(BuildContext context) {
-    return const Placeholder();
+    return BigMeishiView(meishiId: meishiId);
   }
 }

--- a/lib/screens/detail/detail_screen.dart
+++ b/lib/screens/detail/detail_screen.dart
@@ -1,5 +1,6 @@
 import 'package:e_meishi/components/big_meishi_view.dart';
 import 'package:e_meishi/components/single_line_description.dart';
+import 'package:e_meishi/components/long_description.dart';
 import 'package:flutter/material.dart';
 
 class DetailScreen extends StatelessWidget {
@@ -13,14 +14,21 @@ class DetailScreen extends StatelessWidget {
         appBar: AppBar(
           title: const Text(('名刺詳細ページ')),
         ),
-        body: Column(
-          children: [
-            BigMeishiView(meishiId: meishiId),
-            const Padding(
-              padding: EdgeInsets.all(8.0),
-              child: OneLineDescription(hintText: '名前'),
-            )
-          ],
+        body: SingleChildScrollView(
+          child: Column(
+            children: [
+              BigMeishiView(meishiId: meishiId),
+              const Padding(
+                padding: EdgeInsets.all(8.0),
+                child: Column(
+                  children: [
+                    OneLineDescription(hintText: '名前'),
+                    LongDescription(hintText: '名刺の説明やメモなど'),
+                  ],
+                ),
+              )
+            ],
+          ),
         ));
   }
 }

--- a/lib/screens/detail/detail_screen.dart
+++ b/lib/screens/detail/detail_screen.dart
@@ -1,4 +1,5 @@
 import 'package:e_meishi/components/big_meishi_view.dart';
+import 'package:e_meishi/components/single_line_description.dart';
 import 'package:flutter/material.dart';
 
 class DetailScreen extends StatelessWidget {
@@ -10,8 +11,16 @@ class DetailScreen extends StatelessWidget {
   Widget build(BuildContext context) {
     return Scaffold(
         appBar: AppBar(
-          title: Text(('名刺詳細ページ')),
+          title: const Text(('名刺詳細ページ')),
         ),
-        body: BigMeishiView(meishiId: meishiId));
+        body: Column(
+          children: [
+            BigMeishiView(meishiId: meishiId),
+            const Padding(
+              padding: EdgeInsets.all(8.0),
+              child: OneLineDescription(hintText: '名前'),
+            )
+          ],
+        ));
   }
 }

--- a/lib/screens/detail/detail_screen.dart
+++ b/lib/screens/detail/detail_screen.dart
@@ -33,7 +33,7 @@ class DetailScreen extends StatelessWidget {
                     ),
                     OneLineDescription(hintText: '所属'),
                     OneLineDescription(hintText: '電話番号'),
-                    LongDescription(hintText: '名刺の説明やメモなど'),
+                    LongDescription(hintText: 'メモなど'),
                   ],
                 ),
               )


### PR DESCRIPTION
## 概要
名刺詳細ページと使用するコンポーネントを作成

## プルリクについて
このブランチに複数のブランチをマージしてさらにそこから
developブランチへマージするためのプルリクです。

## 対応issue
#109 #110 #112 #113 #115 

## 更新内容
- /detailのルーティング #111
- BigmeishiViewを上部に設置 #114 
- 1行記述式コンポーネントを作成 #117 
- 長文記述式コンポーネントを作成 #118 
- 名刺詳細ページのスタイリング #119 

各更新内容の詳細はそれぞれのプルリクに記載あり

## テスト
1.アプリを起動
2./detailに遷移
3.UIを確認

## 注意点
名刺を表示されているものは今は自分の名刺だけしか表示されません。
それぞれの名刺を表示させるのは機能面での実装の時に変更予定です。
このプルリクの変更はUI面のことのみです。

## スクリーンショット
<div style="display:flex;">
  <img src="https://github.com/user-attachments/assets/9a6dc408-75b6-4e0a-8f0a-d3f34ed0115e"
width="300" alt="スクリーンショット1"  />
</div>

## その他
特になし