### PR TITLE
名刺管理画面TabBarのgrid_cardsをローカルDBと結合

### DIFF
--- a/lib/components/grid_cards.dart
+++ b/lib/components/grid_cards.dart
@@ -2,6 +2,12 @@ import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:e_meishi/models/meishi.dart';
 import 'package:path_provider/path_provider.dart';
+import 'package:intl/intl.dart';
+
+String formatDate(DateTime? date) {
+  if (date == null) return '日付なし';
+  return DateFormat('M/d').format(date);
+}
 
 class GridCards extends StatelessWidget {
   final List<Meishi> meishis;
@@ -56,7 +62,7 @@ class GridCards extends StatelessWidget {
                         padding: const EdgeInsets.symmetric(
                             horizontal: 4.0, vertical: 2.0),
                         child: Text(
-                          '${meishi.addedTime}',
+                          formatDate(meishi.addedTime),
                           style: const TextStyle(
                               fontSize: 10, color: Colors.white),
                         ),

--- a/lib/components/grid_cards.dart
+++ b/lib/components/grid_cards.dart
@@ -1,61 +1,76 @@
+import 'dart:io';
 import 'package:flutter/material.dart';
+import 'package:e_meishi/models/meishi.dart';
+import 'package:path_provider/path_provider.dart';
 
 class GridCards extends StatelessWidget {
-  final List<Map<String, String>> list;
+  final List<Meishi> meishis;
   final bool isScrollable;
-  const GridCards({super.key, required this.list, this.isScrollable = true});
+
+  const GridCards({super.key, required this.meishis, this.isScrollable = true});
+
+  Future<String> getImageFilePath(String imageName) async {
+    final dir = await getApplicationDocumentsDirectory();
+    return '${dir.path}/camera/pictures/$imageName';
+  }
 
   @override
   Widget build(BuildContext context) {
     return Padding(
       padding: const EdgeInsets.all(8.0),
       child: GridView.builder(
-          shrinkWrap: !isScrollable,
-          physics: isScrollable
-              ? const AlwaysScrollableScrollPhysics()
-              : const NeverScrollableScrollPhysics(),
-          gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
-              crossAxisCount: 2,
-              mainAxisSpacing: 8,
-              crossAxisSpacing: 8,
-              childAspectRatio: 8 / 5),
-          itemCount: list.length,
-          itemBuilder: (context, index) {
-            final imageUrl = list[index]['imageUrl'] ?? '';
-            final addedTime = list[index]['addedTime'] ?? '';
-
-            return Stack(
-              children: [
-                ClipRRect(
-                  borderRadius: BorderRadius.circular(8),
-                  child: Image.network(
-                    imageUrl,
-                    fit: BoxFit.cover,
-                    width: double.infinity,
-                    height: double.infinity,
-                  ),
-                ),
-                Positioned(
-                  top: 8,
-                  left: 8,
-                  child: Container(
-                    color: Colors.black.withOpacity(0.1), // 半透明の背景色
-                    child: Padding(
-                      padding: const EdgeInsets.symmetric(
-                          horizontal: 4.0, vertical: 2.0),
-                      child: Text(
-                        addedTime, // 動的に設定可能な登録日
-                        style: const TextStyle(
-                          fontSize: 10,
-                          color: Colors.white, // テキストを白色に
+        shrinkWrap: !isScrollable,
+        physics: isScrollable
+            ? const AlwaysScrollableScrollPhysics()
+            : const NeverScrollableScrollPhysics(),
+        gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
+          crossAxisCount: 2,
+          mainAxisSpacing: 8,
+          crossAxisSpacing: 8,
+          childAspectRatio: 8 / 5,
+        ),
+        itemCount: meishis.length,
+        itemBuilder: (context, index) {
+          final meishi = meishis[index];
+          return FutureBuilder<String>(
+            future: getImageFilePath(meishi.imageName),
+            builder: (context, snapshot) {
+              if (snapshot.connectionState == ConnectionState.done &&
+                  snapshot.hasData) {
+                return Stack(
+                  children: [
+                    ClipRRect(
+                      borderRadius: BorderRadius.circular(8),
+                      child: Image.file(
+                        File(snapshot.data!),
+                        fit: BoxFit.cover,
+                        width: double.infinity,
+                        height: double.infinity,
+                      ),
+                    ),
+                    Positioned(
+                      top: 8,
+                      left: 8,
+                      child: Container(
+                        color: Colors.black.withOpacity(0.5),
+                        padding: const EdgeInsets.symmetric(
+                            horizontal: 4.0, vertical: 2.0),
+                        child: Text(
+                          '${meishi.addedTime}',
+                          style: const TextStyle(
+                              fontSize: 10, color: Colors.white),
                         ),
                       ),
                     ),
-                  ),
-                ),
-              ],
-            );
-          }),
+                  ],
+                );
+              } else {
+                return const Center(child: CircularProgressIndicator());
+              }
+            },
+          );
+        },
+      ),
     );
   }
 }

--- a/lib/screens/management/management_screen.dart
+++ b/lib/screens/management/management_screen.dart
@@ -1,27 +1,16 @@
-import 'package:e_meishi/components/grid_cards.dart';
 import 'package:flutter/material.dart';
+import 'package:e_meishi/components/grid_cards.dart';
 import 'package:e_meishi/components/search_field.dart';
+import 'package:e_meishi/models/meishi.dart';
+import 'package:e_meishi/utils/utils.dart';
 
 class ManagementScreen extends StatelessWidget {
   ManagementScreen({super.key});
 
   final List<Widget> _tabs = [
-    const Tab(icon: Icon(Icons.new_releases), text: '新着順'), // 新着順用のアイコン
-    const Tab(icon: Icon(Icons.history), text: '古い順'), // 古い順用のアイコン
-    const Tab(icon: Icon(Icons.bookmark), text: 'マーク'), // マーク用のアイコン
-  ];
-
-  final List<Map<String, String>> list = [
-    {'imageUrl': 'https://placehold.jp/380x240.png', 'addedTime': '2024-09-01'},
-    {'imageUrl': 'https://placehold.jp/360x230.png', 'addedTime': '2024-08-30'},
-    {'imageUrl': 'https://placehold.jp/340x220.png', 'addedTime': '2024-08-28'},
-    {'imageUrl': 'https://placehold.jp/320x210.png', 'addedTime': '2024-08-25'},
-    {'imageUrl': 'https://placehold.jp/300x200.png', 'addedTime': '2024-08-20'},
-    {'imageUrl': 'https://placehold.jp/280x190.png', 'addedTime': '2024-08-18'},
-    {'imageUrl': 'https://placehold.jp/260x180.png', 'addedTime': '2024-08-15'},
-    {'imageUrl': 'https://placehold.jp/240x170.png', 'addedTime': '2024-08-10'},
-    {'imageUrl': 'https://placehold.jp/220x160.png', 'addedTime': '2024-08-05'},
-    {'imageUrl': 'https://placehold.jp/200x150.png', 'addedTime': '2024-08-01'},
+    const Tab(icon: Icon(Icons.new_releases), text: '新着順'), // 新着順
+    const Tab(icon: Icon(Icons.history), text: '古い順'), // 古い順
+    const Tab(icon: Icon(Icons.bookmark), text: 'マーク'), // マークされた項目
   ];
 
   @override
@@ -31,24 +20,34 @@ class ManagementScreen extends StatelessWidget {
       child: Scaffold(
         appBar: AppBar(
           title: const SearchField(),
-          bottom: TabBar(
-            tabs: _tabs,
-          ),
+          bottom: TabBar(tabs: _tabs),
         ),
         body: TabBarView(
           children: [
-            GridCards(
-              list: list,
-            ), // 新着順
-            GridCards(
-              list: list,
-            ), // 古い順
-            GridCards(
-              list: list,
-            ), // マーク
+            buildTabView(SortOrder.newest),
+            buildTabView(SortOrder.oldest),
+            buildTabView(SortOrder.marked),
           ],
         ),
       ),
+    );
+  }
+
+  Widget buildTabView(SortOrder sortOrder) {
+    return FutureBuilder<List<Meishi>>(
+      future: getMeishis(sortOrder),
+      builder: (context, snapshot) {
+        if (snapshot.connectionState == ConnectionState.done) {
+          if (snapshot.hasError) {
+            return const Center(child: Text('エラーが発生しました'));
+          } else if (snapshot.hasData && snapshot.data != null) {
+            return GridCards(meishis: snapshot.data!, isScrollable: true);
+          } else {
+            return const Center(child: Text('データがありません'));
+          }
+        }
+        return const Center(child: CircularProgressIndicator());
+      },
     );
   }
 }

--- a/lib/utils/utils.dart
+++ b/lib/utils/utils.dart
@@ -1,7 +1,10 @@
+import 'package:e_meishi/models/meishi.dart';
 import 'package:flutter/material.dart';
 import 'package:e_meishi/components/loading_dialog.dart';
 import 'package:e_meishi/components/check_dialog.dart';
 import 'package:e_meishi/components/error_dialog.dart';
+import 'package:isar/isar.dart';
+import 'package:path_provider/path_provider.dart';
 
 void showLoadingDialog(BuildContext context, String message) {
   showDialog(
@@ -29,4 +32,16 @@ void showErrorDialog(BuildContext context, String errorMessage) {
       builder: (BuildContext context) {
         return ErrorDialog(errorMessage: errorMessage);
       });
+}
+
+/*DB関連*/
+// 新着順リスト形式で名刺を取得
+Future<List<Meishi>> getRecent() async {
+  final Isar? isar = Isar.getInstance(); // Isarインスタンスを取得
+  if (isar == null) {
+    return []; // Isarインスタンスがnullの場合、空のリストを返す
+  }
+  final List<Meishi> meishis =
+      await isar.meishis.where().sortByAddedTimeDesc().findAll(); // 名刺を新着順に取得
+  return meishis;
 }

--- a/lib/utils/utils.dart
+++ b/lib/utils/utils.dart
@@ -4,7 +4,6 @@ import 'package:e_meishi/components/loading_dialog.dart';
 import 'package:e_meishi/components/check_dialog.dart';
 import 'package:e_meishi/components/error_dialog.dart';
 import 'package:isar/isar.dart';
-import 'package:path_provider/path_provider.dart';
 
 void showLoadingDialog(BuildContext context, String message) {
   showDialog(
@@ -34,14 +33,27 @@ void showErrorDialog(BuildContext context, String errorMessage) {
       });
 }
 
-/*DB関連*/
-// 新着順リスト形式で名刺を取得
-Future<List<Meishi>> getRecent() async {
-  final Isar? isar = Isar.getInstance(); // Isarインスタンスを取得
+// DB関連
+enum SortOrder { newest, oldest, marked }
+
+Future<List<Meishi>> getMeishis(SortOrder sortOrder) async {
+  final Isar? isar = Isar.getInstance(); // Isarインスタンスを取得、null許容型として扱う
   if (isar == null) {
-    return []; // Isarインスタンスがnullの場合、空のリストを返す
+    throw Exception('Database not available'); // ここでエラーハンドリング、または空のリストを返す等
   }
-  final List<Meishi> meishis =
-      await isar.meishis.where().sortByAddedTimeDesc().findAll(); // 名刺を新着順に取得
-  return meishis;
+
+  switch (sortOrder) {
+    case SortOrder.newest:
+      return await isar.meishis.where().sortByAddedTimeDesc().findAll();
+    case SortOrder.oldest:
+      return await isar.meishis.where().sortByAddedTime().findAll();
+    case SortOrder.marked:
+      // マークされた名刺を取得するロジックをここに実装します。例えば:
+      return await isar.meishis
+          .where()
+          .sortByAddedTimeDesc()
+          .findAll(); //未実装のため仮に新着順を表示
+    default:
+      return [];
+  }
 }

--- a/lib/utils/utils.dart
+++ b/lib/utils/utils.dart
@@ -48,7 +48,6 @@ Future<List<Meishi>> getMeishis(SortOrder sortOrder) async {
     case SortOrder.oldest:
       return await isar.meishis.where().sortByAddedTime().findAll();
     case SortOrder.marked:
-      // マークされた名刺を取得するロジックをここに実装します。例えば:
       return await isar.meishis
           .where()
           .sortByAddedTimeDesc()

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -408,6 +408,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.2.0"
+  intl:
+    dependency: "direct main"
+    description:
+      name: intl
+      sha256: d6f56758b7d3014a48af9701c085700aac781a92a87a62b1333b46d8879661cf
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.19.0"
   io:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -44,6 +44,7 @@ dependencies:
   flutter_native_splash:
   isar: ^3.1.0+1
   isar_flutter_libs: ^3.1.0+1
+  intl: ^0.19.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## 概要
名刺管理画面TabBarのgrid_cardsをローカルDBと結合した

## プルリクについて
developブランチへマージするためのプルリクです。

## 対応issue
#128 

## 更新内容
- grid_cardsの新着順,古い順をローカルDBと結合
- マークは未実装のため仮に新着順を表示
- addedTimeをフォーマットしてM月d日の表示にした

## テスト
1.アプリを起動
2./managementに遷移
3.UIを確認

## 注意点
名刺履歴に使用されているgrid_cardsは名刺履歴保存の処理が開発できていないため、そのままです。
マークも同じで機能が開発できていないため、そのままです。
それぞれの機能が開発でき次第機能追加していきます。

## スクリーンショット
<div style="display:flex;">
  <img src="https://github.com/user-attachments/assets/6190a329-132d-4832-9ee4-b0478ba97e8f"
width="250" alt="スクリーンショット1"  />
  <img src="https://github.com/user-attachments/assets/e68a5af8-e6cb-4c59-a701-9f20a8f1d565"
width="250" alt="スクリーンショット2"  />
  <img src="https://github.com/user-attachments/assets/57cf4a94-584e-4266-aee5-f881ab5f6015"
width="250" alt="スクリーンショット3"  />
</div>

## その他
特になし