### PR TITLE
各コンポーネントをタップで名刺詳細ページに遷移

### DIFF
--- a/lib/components/big_meishi_view.dart
+++ b/lib/components/big_meishi_view.dart
@@ -1,5 +1,6 @@
 import 'package:e_meishi/models/meishi.dart';
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
 import 'dart:io';
 import 'package:isar/isar.dart';
 import 'package:path_provider/path_provider.dart';
@@ -38,7 +39,11 @@ class BigMeishiView extends StatelessWidget {
               margin: const EdgeInsets.all(5),
               decoration: BoxDecoration(
                   border: Border.all(color: Colors.grey, width: 3)),
-              child: Image.file(File(snapshot.data!)));
+              child: InkWell(
+                  onTap: () {
+                    context.push('/detail');
+                  },
+                  child: Image.file(File(snapshot.data!))));
         },
       ),
     ]);

--- a/lib/components/grid_cards.dart
+++ b/lib/components/grid_cards.dart
@@ -1,6 +1,7 @@
 import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:e_meishi/models/meishi.dart';
+import 'package:go_router/go_router.dart';
 import 'package:path_provider/path_provider.dart';
 import 'package:intl/intl.dart';
 
@@ -45,13 +46,18 @@ class GridCards extends StatelessWidget {
                   snapshot.hasData) {
                 return Stack(
                   children: [
-                    ClipRRect(
-                      borderRadius: BorderRadius.circular(8),
-                      child: Image.file(
-                        File(snapshot.data!),
-                        fit: BoxFit.cover,
-                        width: double.infinity,
-                        height: double.infinity,
+                    InkWell(
+                      onTap: () {
+                        context.push('/detail');
+                      },
+                      child: ClipRRect(
+                        borderRadius: BorderRadius.circular(8),
+                        child: Image.file(
+                          File(snapshot.data!),
+                          fit: BoxFit.cover,
+                          width: double.infinity,
+                          height: double.infinity,
+                        ),
                       ),
                     ),
                     Positioned(

--- a/lib/components/sample_carousel.dart
+++ b/lib/components/sample_carousel.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
 
 class SampleCarousel extends StatelessWidget {
   final String title;
@@ -36,11 +37,17 @@ class SampleCarousel extends StatelessWidget {
                         padding: const EdgeInsets.symmetric(horizontal: 4),
                         child: AspectRatio(
                           aspectRatio: 8 / 5, // アイテムのアスペクト比を指定
-                          child: ClipRRect(
-                            borderRadius: BorderRadius.circular(5), // 角丸の半径を指定
-                            child: Image.network(
-                              imageUrls[index], // 画像のURLを表示
-                              fit: BoxFit.cover, // 画像をコンテナ全体にフィット
+                          child: InkWell(
+                            onTap: () {
+                              context.push('/detail');
+                            },
+                            child: ClipRRect(
+                              borderRadius:
+                                  BorderRadius.circular(5), // 角丸の半径を指定
+                              child: Image.network(
+                                imageUrls[index], // 画像のURLを表示
+                                fit: BoxFit.cover, // 画像をコンテナ全体にフィット
+                              ),
                             ),
                           ),
                         ),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -115,11 +115,10 @@ class MyApp extends StatelessWidget {
           },
         ),
         GoRoute(
-          path: '/detail',
+          path: '/detail/:id',
           builder: (BuildContext context, GoRouterState state) {
-            return const DetailScreen(
-              meishiId: 1,
-            );
+            return DetailScreen(
+                meishiId: int.parse(state.pathParameters['id']!));
           },
         ),
       ],


### PR DESCRIPTION
## 概要
各コンポーネントをタップして名刺詳細ページに遷移する処理を追加

## プルリクについて
feature/detail-page-db-integrationブランチへマージするためのプルリクです。

## 対応issue
#134 
#126 

## 更新内容
- BigMeishiView,SampleCarousel,grid_cardsから/detailに遷移する処理を追加
- main.dartに書かれているルーティングにidパラメータを追加(/detail/:id)

## テスト
1.アプリを起動
2.名刺管理遷移
3.名刺をタップし名刺詳細ページに遷移
4.UIを確認

## 注意点
遷移する処理を追加するためのプルリクのため、他コンポーネントの動的に変化させる処理は別のプルリクにて作業したいと考えています。
また、BigMeishiViewに関してはmeishiIdを参照しているため、現時点で動的に変化するようになっています。(#126)

## スクリーンショット
特になし

## その他
特になし