### PR TITLE
1行記述式コンポーネントに初期値を追加

### DIFF
--- a/lib/components/grid_cards.dart
+++ b/lib/components/grid_cards.dart
@@ -48,7 +48,7 @@ class GridCards extends StatelessWidget {
                   children: [
                     InkWell(
                       onTap: () {
-                        context.push('/detail');
+                        context.push('/detail/${meishi.id}');
                       },
                       child: ClipRRect(
                         borderRadius: BorderRadius.circular(8),

--- a/lib/components/single_line_description.dart
+++ b/lib/components/single_line_description.dart
@@ -2,7 +2,8 @@ import 'package:flutter/material.dart';
 
 class OneLineDescription extends StatelessWidget {
   final String hintText;
-  const OneLineDescription({super.key, required this.hintText});
+  final String mainText;
+  const OneLineDescription({super.key, required this.hintText, required this.mainText});
 
   @override
   Widget build(BuildContext context) {

--- a/lib/components/single_line_description.dart
+++ b/lib/components/single_line_description.dart
@@ -1,9 +1,29 @@
 import 'package:flutter/material.dart';
 
-class OneLineDescription extends StatelessWidget {
+class OneLineDescription extends StatefulWidget {
   final String hintText;
   final String mainText;
-  const OneLineDescription({super.key, required this.hintText, required this.mainText});
+  const OneLineDescription(
+      {super.key, required this.hintText, required this.mainText});
+
+  @override
+  State<OneLineDescription> createState() => _OneLineDescriptionState();
+}
+
+class _OneLineDescriptionState extends State<OneLineDescription> {
+  final TextEditingController _controller = TextEditingController(text: '');
+
+  @override
+  void initState() {
+    super.initState();
+    _controller.text = widget.mainText;
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -15,11 +35,12 @@ class OneLineDescription extends StatelessWidget {
           Padding(
             padding: const EdgeInsets.symmetric(horizontal: 8.0, vertical: 4.0),
             child: Text(
-              hintText,
+              widget.hintText,
               style: const TextStyle(fontSize: 14, fontWeight: FontWeight.bold),
             ),
           ),
           TextField(
+            controller: _controller,
             decoration: InputDecoration(
                 filled: true,
                 fillColor: Colors.grey[200],

--- a/lib/screens/detail/detail_screen.dart
+++ b/lib/screens/detail/detail_screen.dart
@@ -2,6 +2,8 @@ import 'package:e_meishi/components/big_meishi_view.dart';
 import 'package:e_meishi/components/single_line_description.dart';
 import 'package:e_meishi/components/long_description.dart';
 import 'package:flutter/material.dart';
+import 'package:e_meishi/utils/utils.dart';
+import 'package:e_meishi/models/meishi.dart';
 
 class DetailScreen extends StatelessWidget {
   final int meishiId;
@@ -14,31 +16,65 @@ class DetailScreen extends StatelessWidget {
         appBar: AppBar(
           title: const Text(('名刺詳細ページ')),
         ),
-        body: SingleChildScrollView(
-          child: Column(
-            children: [
-              BigMeishiView(meishiId: meishiId),
-              const Padding(
-                padding: EdgeInsets.all(8.0),
+        body: FutureBuilder<Meishi>(
+            future: getMeishiData(meishiId),
+            builder: (context, snapshot) {
+              if (snapshot.connectionState == ConnectionState.waiting) {
+                return const Center(
+                    child: CircularProgressIndicator()); // データ取得中のローディング表示
+              } else if (snapshot.hasError) {
+                return Center(
+                    child: Text('エラーが発生しました: ${snapshot.error}')); // エラーメッセージ表示
+              } else if (!snapshot.hasData || snapshot.data == null) {
+                return const Center(child: Text('データが見つかりません')); // データがない場合の表示
+              }
+
+              final meishiData = snapshot.data;
+
+              return SingleChildScrollView(
                 child: Column(
                   children: [
-                    OneLineDescription(hintText: '名前'),
-                    Row(
-                      mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                      children: [
-                        Expanded(child: OneLineDescription(hintText: '性別')),
-                        SizedBox(width: 8),
-                        Expanded(child: OneLineDescription(hintText: '年齢')),
-                      ],
-                    ),
-                    OneLineDescription(hintText: '所属'),
-                    OneLineDescription(hintText: '電話番号'),
-                    LongDescription(hintText: 'メモなど'),
+                    BigMeishiView(meishiId: meishiId),
+                    Padding(
+                      padding: const EdgeInsets.all(8.0),
+                      child: Column(
+                        children: [
+                          OneLineDescription(
+                            hintText: '名前',
+                            mainText: meishiData?.userName ?? '取得できませんでした',
+                          ),
+                          Row(
+                            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                            children: [
+                              Expanded(
+                                  child: OneLineDescription(
+                                hintText: '性別',
+                                mainText: meishiData?.gender ?? '取得できませんでした',
+                              )),
+                              const SizedBox(width: 8),
+                              Expanded(
+                                  child: OneLineDescription(
+                                hintText: '年齢',
+                                mainText: meishiData?.age ?? '取得できませんでした',
+                              )),
+                            ],
+                          ),
+                          OneLineDescription(
+                            hintText: '所属',
+                            mainText: meishiData?.affiliation ??
+                                '取得できませんでした',
+                          ),
+                          OneLineDescription(
+                            hintText: '電話番号',
+                            mainText: meishiData?.phoneNumber ?? '取得できませんでした',
+                          ),
+                          const LongDescription(hintText: 'メモなど'),
+                        ],
+                      ),
+                    )
                   ],
                 ),
-              )
-            ],
-          ),
-        ));
+              );
+            }));
   }
 }

--- a/lib/utils/utils.dart
+++ b/lib/utils/utils.dart
@@ -37,7 +37,7 @@ void showErrorDialog(BuildContext context, String errorMessage) {
 enum SortOrder { newest, oldest, marked }
 
 Future<List<Meishi>> getMeishis(SortOrder sortOrder) async {
-  final Isar? isar = Isar.getInstance(); // Isarインスタンスを取得、null許容型として扱う
+  final Isar? isar = Isar.getInstance(); 
   if (isar == null) {
     throw Exception('Database not available'); // ここでエラーハンドリング、または空のリストを返す等
   }
@@ -55,4 +55,16 @@ Future<List<Meishi>> getMeishis(SortOrder sortOrder) async {
     default:
       return [];
   }
+}
+
+Future<Meishi> getMeishiData(meishiId) async {
+  final Isar? isar = Isar.getInstance();
+  if (isar == null) {
+    throw Exception('Database not available');
+  }
+  final meishi = await isar.meishis.get(meishiId);
+  if (meishi == null) {
+    throw Exception('Meishi not found');
+  }
+  return meishi;
 }


### PR DESCRIPTION
## 概要
1行記述式コンポーネントに初期値(保存されているテキスト)を追加した

## プルリクについて
[feature/detail-page-db-integration](https://github.com/shi0n0/e-meishi/tree/feature/detail-page-db-integration)ブランチへマージするためのプルリクです。

## 対応issue
#21 
#124 

## 更新内容
- single_line_descriptionにmainTextを追加
- single_line_descriptionにコントローラーを追加し初期値をmainTextに設定
- getMeishiData関数を追加(IDでデータを取得する関数)

## テスト
1.アプリを起動
2./detailに遷移
3.UIを確認

## 注意点
UIを確認しても初期値が反映されていないように見えますが、実際にはDBに値がない(登録する手段が現状ない)ため、
空欄になっているだけです。近いうちに実装するデータを登録する処理を実装したら児童的にこちらも反映されます。

## スクリーンショット
上記の理由のため、UI上の変更なし

## その他
特になし