### PR TITLE
長文記述式コンポーネントに初期値を追加

### DIFF
--- a/lib/components/long_description.dart
+++ b/lib/components/long_description.dart
@@ -1,8 +1,29 @@
 import 'package:flutter/material.dart';
 
-class LongDescription extends StatelessWidget {
+class LongDescription extends StatefulWidget {
   final String hintText;
-  const LongDescription({super.key, required this.hintText});
+  final String mainText;
+  const LongDescription(
+      {super.key, required this.hintText, required this.mainText});
+
+  @override
+  State<LongDescription> createState() => _LongDescriptionState();
+}
+
+class _LongDescriptionState extends State<LongDescription> {
+  final TextEditingController _controller = TextEditingController(text: '');
+
+  @override
+  void initState() {
+    super.initState();
+    _controller.text = widget.mainText;
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -14,11 +35,12 @@ class LongDescription extends StatelessWidget {
           Padding(
             padding: const EdgeInsets.symmetric(horizontal: 8.0, vertical: 4.0),
             child: Text(
-              hintText,
+              widget.hintText,
               style: const TextStyle(fontSize: 14, fontWeight: FontWeight.bold),
             ),
           ),
           TextField(
+              controller: _controller,
               decoration: InputDecoration(
                 filled: true,
                 fillColor: Colors.grey[200],

--- a/lib/screens/detail/detail_screen.dart
+++ b/lib/screens/detail/detail_screen.dart
@@ -61,14 +61,16 @@ class DetailScreen extends StatelessWidget {
                           ),
                           OneLineDescription(
                             hintText: '所属',
-                            mainText: meishiData?.affiliation ??
-                                '取得できませんでした',
+                            mainText: meishiData?.affiliation ?? '取得できませんでした',
                           ),
                           OneLineDescription(
                             hintText: '電話番号',
                             mainText: meishiData?.phoneNumber ?? '取得できませんでした',
                           ),
-                          const LongDescription(hintText: 'メモなど'),
+                          LongDescription(
+                            hintText: 'メモなど',
+                            mainText: meishiData?.memo ?? '取得できませんでした',
+                          ),
                         ],
                       ),
                     )


### PR DESCRIPTION
## 概要
長文記述式コンポーネントに初期値(保存されているテキスト)を追加した

## プルリクについて
[feature/detail-page-db-integration](https://github.com/shi0n0/e-meishi/tree/feature/detail-page-db-integration)ブランチへマージするためのプルリクです。

## 対応issue
#21
#125  

## 更新内容
- long_descriptionにmainTextを追加
- long_descriptionにコントローラーを追加し初期値をmainTextに設定
- detail_screenのlong_descriptionにmainTextを渡す処理

## テスト
1.アプリを起動
2./detailに遷移
3.UIを確認

## 注意点
UIを確認しても初期値が反映されていないように見えますが、実際にはDBに値がない(登録する手段が現状ない)ため、
空欄になっているだけです。近いうちに実装するデータを登録する処理を実装したら自動的にこちらも反映されます。

## スクリーンショット
上記の理由のため、UI上の変更なし

## その他
特になし