### PR TITLE
1行記述式コンポーネントを保存/更新する処理を作成

### DIFF
--- a/lib/components/single_line_description.dart
+++ b/lib/components/single_line_description.dart
@@ -2,28 +2,17 @@ import 'package:flutter/material.dart';
 
 class OneLineDescription extends StatefulWidget {
   final String hintText;
-  final String mainText;
+  final TextEditingController controller;
+
   const OneLineDescription(
-      {super.key, required this.hintText, required this.mainText});
+      {super.key, required this.hintText, required this.controller});
 
   @override
   State<OneLineDescription> createState() => _OneLineDescriptionState();
 }
 
 class _OneLineDescriptionState extends State<OneLineDescription> {
-  final TextEditingController _controller = TextEditingController(text: '');
 
-  @override
-  void initState() {
-    super.initState();
-    _controller.text = widget.mainText;
-  }
-
-  @override
-  void dispose() {
-    _controller.dispose();
-    super.dispose();
-  }
 
   @override
   Widget build(BuildContext context) {
@@ -40,7 +29,7 @@ class _OneLineDescriptionState extends State<OneLineDescription> {
             ),
           ),
           TextField(
-            controller: _controller,
+            controller: widget.controller,
             decoration: InputDecoration(
                 filled: true,
                 fillColor: Colors.grey[200],

--- a/lib/screens/detail/detail_screen.dart
+++ b/lib/screens/detail/detail_screen.dart
@@ -4,20 +4,82 @@ import 'package:e_meishi/components/long_description.dart';
 import 'package:flutter/material.dart';
 import 'package:e_meishi/utils/utils.dart';
 import 'package:e_meishi/models/meishi.dart';
+import 'package:isar/isar.dart';
 
-class DetailScreen extends StatelessWidget {
+class DetailScreen extends StatefulWidget {
   final int meishiId;
 
   const DetailScreen({super.key, required this.meishiId});
+
+  @override
+  State<DetailScreen> createState() => _DetailScreenState();
+}
+
+class _DetailScreenState extends State<DetailScreen> {
+  late final Isar _isar;
+  final TextEditingController _nameController = TextEditingController();
+  final TextEditingController _genderController = TextEditingController();
+  final TextEditingController _ageController = TextEditingController();
+  final TextEditingController _affiliationController = TextEditingController();
+  final TextEditingController _phoneNumberController = TextEditingController();
+
+  late Future<Meishi?> _meishiData;
+
+  @override
+  void initState() {
+    super.initState();
+    _isar = Isar.getInstance()!;
+    _meishiData = getMeishiData(widget.meishiId);
+
+    // データを取得してコントローラに初期値を設定
+    _meishiData.then((meishi) {
+      if (meishi != null) {
+        _nameController.text = meishi.userName;
+        _genderController.text = meishi.gender;
+        _ageController.text = meishi.age;
+        _affiliationController.text = meishi.affiliation;
+        _phoneNumberController.text = meishi.phoneNumber;
+      }
+    });
+  }
+
+  //　コントローラーを破棄
+  @override
+  void dispose() {
+    _nameController.dispose();
+    _genderController.dispose();
+    _ageController.dispose();
+    _affiliationController.dispose();
+    _phoneNumberController.dispose();
+    super.dispose();
+  }
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
         appBar: AppBar(
           title: const Text(('名刺詳細ページ')),
+          actions: [
+            IconButton(
+              icon: const Icon(Icons.save),
+              onPressed: () => saveMeishiData(
+                      _isar,
+                      widget.meishiId,
+                      _nameController,
+                      _genderController,
+                      _ageController,
+                      _phoneNumberController,
+                      _affiliationController)
+                  .then((_) {
+                ScaffoldMessenger.of(context).showSnackBar(
+                  const SnackBar(content: Text('データが保存されました')),
+                );
+              }),
+            ),
+          ],
         ),
         body: FutureBuilder<Meishi>(
-            future: getMeishiData(meishiId),
+            future: getMeishiData(widget.meishiId),
             builder: (context, snapshot) {
               if (snapshot.connectionState == ConnectionState.waiting) {
                 return const Center(
@@ -34,14 +96,14 @@ class DetailScreen extends StatelessWidget {
               return SingleChildScrollView(
                 child: Column(
                   children: [
-                    BigMeishiView(meishiId: meishiId),
+                    BigMeishiView(meishiId: widget.meishiId),
                     Padding(
                       padding: const EdgeInsets.all(8.0),
                       child: Column(
                         children: [
                           OneLineDescription(
                             hintText: '名前',
-                            mainText: meishiData?.userName ?? '取得できませんでした',
+                            controller: _nameController,
                           ),
                           Row(
                             mainAxisAlignment: MainAxisAlignment.spaceBetween,
@@ -49,23 +111,23 @@ class DetailScreen extends StatelessWidget {
                               Expanded(
                                   child: OneLineDescription(
                                 hintText: '性別',
-                                mainText: meishiData?.gender ?? '取得できませんでした',
+                                controller: _genderController,
                               )),
                               const SizedBox(width: 8),
                               Expanded(
                                   child: OneLineDescription(
                                 hintText: '年齢',
-                                mainText: meishiData?.age ?? '取得できませんでした',
+                                controller: _ageController,
                               )),
                             ],
                           ),
                           OneLineDescription(
                             hintText: '所属',
-                            mainText: meishiData?.affiliation ?? '取得できませんでした',
+                            controller: _affiliationController,
                           ),
                           OneLineDescription(
                             hintText: '電話番号',
-                            mainText: meishiData?.phoneNumber ?? '取得できませんでした',
+                            controller: _phoneNumberController,
                           ),
                           LongDescription(
                             hintText: 'メモなど',

--- a/lib/utils/utils.dart
+++ b/lib/utils/utils.dart
@@ -34,10 +34,13 @@ void showErrorDialog(BuildContext context, String errorMessage) {
 }
 
 // DB関連
+
+//取得
+
 enum SortOrder { newest, oldest, marked }
 
 Future<List<Meishi>> getMeishis(SortOrder sortOrder) async {
-  final Isar? isar = Isar.getInstance(); 
+  final Isar? isar = Isar.getInstance();
   if (isar == null) {
     throw Exception('Database not available'); // ここでエラーハンドリング、または空のリストを返す等
   }
@@ -67,4 +70,31 @@ Future<Meishi> getMeishiData(meishiId) async {
     throw Exception('Meishi not found');
   }
   return meishi;
+}
+
+Future<void> saveMeishiData(
+  Isar isar,
+  int meishiId,
+  TextEditingController nameController,
+  TextEditingController genderController,
+  TextEditingController ageController,
+  TextEditingController phoneNumberController,
+  TextEditingController affiliationController,
+) async {
+  // トランザクションでデータを保存
+  await isar.writeTxn(() async {
+    final meishi = await isar.meishis.get(meishiId);
+    if (meishi == null) {
+      throw Exception('Meishi not found');
+    }
+    meishi
+      ..id = meishiId
+      ..userName = nameController.text
+      ..gender = genderController.text
+      ..age = ageController.text
+      ..phoneNumber = phoneNumberController.text
+      ..affiliation = affiliationController.text;
+
+    await isar.meishis.put(meishi);
+  });
 }


### PR DESCRIPTION
## 概要
1行記述式コンポーネントを保存/更新する処理を作成した

## プルリクについて
[feature/detail-page-db-integration](https://github.com/shi0n0/e-meishi/tree/feature/detail-page-db-integration)ブランチへマージするためのプルリクです。

## 対応issue
#21
#121 

## 更新内容
- コントローラーをsingleLineDescriptionコンポーネントで作成ではなく、detailPageで一括作成/管理するように変更
- detailPageのコントローラーを各コンポーネントに渡す処理
- コントローラーを一括管理(一括で初期値を設定)して譲渡するため、mainTextが必要なくなったので削除
- コントローラーを元に内容を保存する関数(saveMeishiData)

## テスト
1.アプリを起動
2./detailに遷移
3.UIを確認
4.データを入力し、右上にの保存アイコンを押下
5.保存されているか確認

## 注意点
メモに関しては別コンポーネントになるので別のブランチにて作業します。
既に保存する処理はこのブランチで作っていて、あとはコントローラーを渡すだけになるので
初期値を追加する処理と保存する処理は同一のブランチにて作業することとします。

## スクリーンショット
<div style="display:flex;">
  <img src="https://github.com/user-attachments/assets/6a0dab7f-412a-4e48-a733-1225cdf748b9"
width="250" alt="スクリーンショット1"  />
  <img src="https://github.com/user-attachments/assets/1e3afbde-f7ad-4ad2-b362-2f7a3ab22293"
width="250" alt="スクリーンショット2"  />
</div>

## その他
特になし