### PR TITLE
長文記述式コンポーネントをDBと結合

### DIFF
--- a/lib/components/long_description.dart
+++ b/lib/components/long_description.dart
@@ -2,29 +2,15 @@ import 'package:flutter/material.dart';
 
 class LongDescription extends StatefulWidget {
   final String hintText;
-  final String mainText;
+  final TextEditingController controller;
   const LongDescription(
-      {super.key, required this.hintText, required this.mainText});
+      {super.key, required this.hintText, required this.controller});
 
   @override
   State<LongDescription> createState() => _LongDescriptionState();
 }
 
 class _LongDescriptionState extends State<LongDescription> {
-  final TextEditingController _controller = TextEditingController(text: '');
-
-  @override
-  void initState() {
-    super.initState();
-    _controller.text = widget.mainText;
-  }
-
-  @override
-  void dispose() {
-    _controller.dispose();
-    super.dispose();
-  }
-
   @override
   Widget build(BuildContext context) {
     return Padding(
@@ -40,7 +26,7 @@ class _LongDescriptionState extends State<LongDescription> {
             ),
           ),
           TextField(
-              controller: _controller,
+              controller: widget.controller,
               decoration: InputDecoration(
                 filled: true,
                 fillColor: Colors.grey[200],

--- a/lib/screens/detail/detail_screen.dart
+++ b/lib/screens/detail/detail_screen.dart
@@ -22,6 +22,7 @@ class _DetailScreenState extends State<DetailScreen> {
   final TextEditingController _ageController = TextEditingController();
   final TextEditingController _affiliationController = TextEditingController();
   final TextEditingController _phoneNumberController = TextEditingController();
+  final TextEditingController _memoController = TextEditingController();
 
   late Future<Meishi?> _meishiData;
 
@@ -39,6 +40,7 @@ class _DetailScreenState extends State<DetailScreen> {
         _ageController.text = meishi.age;
         _affiliationController.text = meishi.affiliation;
         _phoneNumberController.text = meishi.phoneNumber;
+        _memoController.text = meishi.memo;
       }
     });
   }
@@ -51,6 +53,7 @@ class _DetailScreenState extends State<DetailScreen> {
     _ageController.dispose();
     _affiliationController.dispose();
     _phoneNumberController.dispose();
+    _memoController.dispose();
     super.dispose();
   }
 
@@ -69,7 +72,8 @@ class _DetailScreenState extends State<DetailScreen> {
                       _genderController,
                       _ageController,
                       _phoneNumberController,
-                      _affiliationController)
+                      _affiliationController,
+                      _memoController)
                   .then((_) {
                 ScaffoldMessenger.of(context).showSnackBar(
                   const SnackBar(content: Text('データが保存されました')),
@@ -90,8 +94,6 @@ class _DetailScreenState extends State<DetailScreen> {
               } else if (!snapshot.hasData || snapshot.data == null) {
                 return const Center(child: Text('データが見つかりません')); // データがない場合の表示
               }
-
-              final meishiData = snapshot.data;
 
               return SingleChildScrollView(
                 child: Column(
@@ -131,7 +133,7 @@ class _DetailScreenState extends State<DetailScreen> {
                           ),
                           LongDescription(
                             hintText: 'メモなど',
-                            mainText: meishiData?.memo ?? '取得できませんでした',
+                            controller: _memoController,
                           ),
                         ],
                       ),

--- a/lib/utils/utils.dart
+++ b/lib/utils/utils.dart
@@ -80,6 +80,7 @@ Future<void> saveMeishiData(
   TextEditingController ageController,
   TextEditingController phoneNumberController,
   TextEditingController affiliationController,
+    TextEditingController memoController
 ) async {
   // トランザクションでデータを保存
   await isar.writeTxn(() async {
@@ -93,7 +94,8 @@ Future<void> saveMeishiData(
       ..gender = genderController.text
       ..age = ageController.text
       ..phoneNumber = phoneNumberController.text
-      ..affiliation = affiliationController.text;
+      ..affiliation = affiliationController.text
+      ..memo = memoController.text;
 
     await isar.meishis.put(meishi);
   });


### PR DESCRIPTION
## 概要
長文記述式コンポーネントのコントローラーを定義し、内容を保存する処理を追加

## プルリクについて
[feature/detail-page-db-integration](https://github.com/shi0n0/e-meishi/tree/feature/detail-page-db-integration)ブランチへマージするためのプルリクです。

## 対応issue
#21 
#122 

## 更新内容
- 既存のコントローラーを削除し,detailPageにてコントローラーを定義
- detailPageにて初期値を設定する処理を追加
- 初期値をdetailPageにて設定するためmainTextを削除
- saveMeishiDataとLongDescriptionにmemoControllerを譲渡
- saveMeishiDataにmemoControllerを元にメモを保存する処理を追加

## テスト
1.アプリを起動
2./detailに遷移
3.UIを確認
4.データを入力し、右上の保存アイコンを押下
5.保存されているか確認

## 注意点
データを保存する処理と初期値を設定する処理を同じブランチにて作業しています。
saveMeishiData関数を既に完成しているため、コントローラーを渡すだけの処理が必要だったためです。

## スクリーンショット
<div style="display:flex;">
  <img src="https://github.com/user-attachments/assets/e8e1179e-e985-4a3e-8ba6-d85be07370af"
width="300" alt="スクリーンショット1"  />
</div>

## その他
特になし