### PR TITLE
lateで定義したフィールドがnullになってしまうため名刺保存の際、空の初期値を設定

### DIFF
--- a/lib/screens/add/display_picture_screen.dart
+++ b/lib/screens/add/display_picture_screen.dart
@@ -58,7 +58,13 @@ class DisplayPictureScreen extends StatelessWidget {
                           // 非同期処理
                           final meishi = Meishi()
                             ..imageName = imageName
-                            ..addedTime = DateTime.now();
+                            ..addedTime = DateTime.now()
+                            ..userName = ''
+                            ..age = ''
+                            ..gender = ''
+                            ..affiliation = ''
+                            ..phoneNumber = ''
+                            ..memo = '';
 
                           await isar.writeTxn(() async {
                             await isar.meishis.put(meishi);


### PR DESCRIPTION
## 概要
lateで定義したフィールドがnullになってしまうため名刺保存の際、空の初期値を設定した

## プルリクについて
[feature/detail-page-db-integration](https://github.com/shi0n0/e-meishi/tree/feature/detail-page-db-integration)ブランチへマージするためのプルリクです。

## 対応issue
#140 

## 更新内容
- display_screenにて名刺を保存する際、各フィールドに空の初期値を追加する

## テスト
1.アプリを起動
2.カメラを起動
3.プレビューにて名刺を保存できるか確認

## 注意点
lateで定義したフィールドはその時点で初期値がないため、必ず後から設定しなくていけません。
ですが、今回の場合は値が設定されていないのにも関わらず他のフィールドを登録しようとしてしまったためエラーが出ました。
detail-pageとは直接関係はないですが、detailでフィールドを追加した際に起きてしまったことなのでそのまままとめてマージしようと思います。

## スクリーンショット
見た目上の変化なし

## その他
特になし