### PR TITLE
名刺の削除機能と確認ダイアログを作成

### DIFF
--- a/lib/components/confirm_dialog.dart
+++ b/lib/components/confirm_dialog.dart
@@ -1,9 +1,13 @@
+import 'package:e_meishi/utils/utils.dart';
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
 
 class ConfirmDialog extends StatelessWidget {
   final String confirmMessage;
+  final int meishiId;
 
-  const ConfirmDialog({super.key, required this.confirmMessage});
+  const ConfirmDialog(
+      {super.key, required this.confirmMessage, required this.meishiId});
 
   @override
   Widget build(BuildContext context) {
@@ -32,6 +36,8 @@ class ConfirmDialog extends StatelessWidget {
                 TextButton(
                   onPressed: () {
                     Navigator.of(context, rootNavigator: true).pop();
+                    deleteMeishi(meishiId);
+                    context.pop();
                   },
                   child: const Text('削除する'),
                 )

--- a/lib/components/confirm_dialog.dart
+++ b/lib/components/confirm_dialog.dart
@@ -1,0 +1,45 @@
+import 'package:flutter/material.dart';
+
+class ConfirmDialog extends StatelessWidget {
+  final String confirmMessage;
+
+  const ConfirmDialog({super.key, required this.confirmMessage});
+
+  @override
+  Widget build(BuildContext context) {
+    return Dialog(
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(10)),
+      child: Padding(
+        padding: const EdgeInsets.all(20),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            const Text('⚠️', style: TextStyle(fontSize: 40, color: Colors.red)),
+            Text(
+              confirmMessage,
+              textAlign: TextAlign.center,
+            ),
+            Row(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                TextButton(
+                  onPressed: () {
+                    Navigator.of(context, rootNavigator: true).pop();
+                  },
+                  child: const Text('キャンセル'),
+                ),
+                TextButton(
+                  onPressed: () {
+                    Navigator.of(context, rootNavigator: true).pop();
+                  },
+                  child: const Text('削除する'),
+                )
+              ],
+            )
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/detail/detail_screen.dart
+++ b/lib/screens/detail/detail_screen.dart
@@ -84,7 +84,8 @@ class _DetailScreenState extends State<DetailScreen> {
               icon: const Icon(Icons.delete),
               color: Colors.red,
               onPressed: () {
-                showConfirmDialog(context, 'この名刺を削除します。\n削除すると二度と復元はできません。');
+                showConfirmDialog(
+                    context, 'この名刺を削除します。\n削除すると二度と復元はできません。', widget.meishiId);
               },
             )
           ],

--- a/lib/screens/detail/detail_screen.dart
+++ b/lib/screens/detail/detail_screen.dart
@@ -80,6 +80,13 @@ class _DetailScreenState extends State<DetailScreen> {
                 );
               }),
             ),
+            IconButton(
+              icon: const Icon(Icons.delete),
+              color: Colors.red,
+              onPressed: () {
+                showConfirmDialog(context, 'この名刺を削除します。\n削除すると二度と復元はできません。');
+              },
+            )
           ],
         ),
         body: FutureBuilder<Meishi>(

--- a/lib/utils/utils.dart
+++ b/lib/utils/utils.dart
@@ -34,12 +34,16 @@ void showErrorDialog(BuildContext context, String errorMessage) {
       });
 }
 
-void showConfirmDialog(BuildContext context, String confirmMessage) {
+void showConfirmDialog(
+    BuildContext context, String confirmMessage, int meishiId) {
   showDialog(
       context: context,
       barrierDismissible: false,
       builder: (BuildContext context) {
-        return ConfirmDialog(confirmMessage: confirmMessage);
+        return ConfirmDialog(
+          confirmMessage: confirmMessage,
+          meishiId: meishiId,
+        );
       });
 }
 
@@ -83,15 +87,14 @@ Future<Meishi> getMeishiData(meishiId) async {
 }
 
 Future<void> saveMeishiData(
-  Isar isar,
-  int meishiId,
-  TextEditingController nameController,
-  TextEditingController genderController,
-  TextEditingController ageController,
-  TextEditingController phoneNumberController,
-  TextEditingController affiliationController,
-    TextEditingController memoController
-) async {
+    Isar isar,
+    int meishiId,
+    TextEditingController nameController,
+    TextEditingController genderController,
+    TextEditingController ageController,
+    TextEditingController phoneNumberController,
+    TextEditingController affiliationController,
+    TextEditingController memoController) async {
   // トランザクションでデータを保存
   await isar.writeTxn(() async {
     final meishi = await isar.meishis.get(meishiId);
@@ -108,5 +111,16 @@ Future<void> saveMeishiData(
       ..memo = memoController.text;
 
     await isar.meishis.put(meishi);
+  });
+}
+
+void deleteMeishi(int meishiId) async {
+  final Isar? isar = Isar.getInstance();
+  if (isar == null) {
+    throw Exception('Database not available');
+  }
+
+  await isar.writeTxn(() async {
+    await isar.meishis.delete(meishiId);
   });
 }

--- a/lib/utils/utils.dart
+++ b/lib/utils/utils.dart
@@ -1,3 +1,4 @@
+import 'package:e_meishi/components/confirm_dialog.dart';
 import 'package:e_meishi/models/meishi.dart';
 import 'package:flutter/material.dart';
 import 'package:e_meishi/components/loading_dialog.dart';
@@ -30,6 +31,15 @@ void showErrorDialog(BuildContext context, String errorMessage) {
       barrierDismissible: false,
       builder: (BuildContext context) {
         return ErrorDialog(errorMessage: errorMessage);
+      });
+}
+
+void showConfirmDialog(BuildContext context, String confirmMessage) {
+  showDialog(
+      context: context,
+      barrierDismissible: false,
+      builder: (BuildContext context) {
+        return ConfirmDialog(confirmMessage: confirmMessage);
       });
 }
 


### PR DESCRIPTION
## 概要
名刺の削除機能と確認ダイアログを追加した

## プルリクについて
[feature/detail-page-db-integration](https://github.com/shi0n0/e-meishi/tree/feature/detail-page-db-integration)ブランチへマージするためのプルリクです。

## 対応issue
#22 

## 更新内容
- 削除ボタンを追加
- 削除機能を追加
- 確認ダイアログを追加
- 確認ダイアログのshow関数を追加

## テスト
1.アプリを起動
2./detailに遷移
3.UIを確認
4.削除ボタンを押す
5.ダイアログを確認
6.キャンセルもしくは削除ボタンを押下
7.削除できているか確認

## 注意点
削除ボタンは赤で色分けしていて、ゴミ箱のアイコンになっているので一目で削除するボタンと分かるようになっています。ですが、３点リーダーから削除できるようにしたほうがユーザー体験的にも良いと思うので将来的には３点リーダーにする予定です

## スクリーンショット
<div style="display:flex;">
  <img src="https://github.com/user-attachments/assets/04337165-5001-4370-bb6c-021400bed68b"
width="300" alt="スクリーンショット1"  />
  <img src="https://github.com/user-attachments/assets/29229054-dd77-4664-8cdb-455b2b387dd2"
width="300" alt="スクリーンショット2"  />
</div>

## その他
特になし