### PR TITLE
GoRouteにデバッグログプロパティを追加

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -3,6 +3,7 @@ import 'package:e_meishi/screens/add/add_meishi.dart';
 import 'package:e_meishi/screens/add/display_picture_screen.dart';
 import 'package:e_meishi/screens/detail/detail_screen.dart';
 import 'package:e_meishi/screens/history/history_screen.dart';
+import 'package:flutter/foundation.dart';
 import 'screens/management/management_screen.dart';
 import 'screens/main/main_screen.dart';
 import 'package:flutter/material.dart';
@@ -45,6 +46,7 @@ class MyApp extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final GoRouter router = GoRouter(
+      debugLogDiagnostics: kDebugMode,
       initialLocation: firstLaunch ? '/introduction' : '/home', // 初期ルートを設定
       routes: [
         GoRoute(


### PR DESCRIPTION
## 概要
GoRouteにデバッグログを出力するプロパティを追加

## プルリクについて
developブランチへマージするためのプルリクです

## 対応issue
#155 

## 更新内容
- main.dartにdebugLogDiagnosticsプロパティを追加

## テスト
1.アプリをデバッグ
2.BottoｍNavigationBarなどでページ遷移
3.ログが出力されるか確認

## 注意点
特になし。
このブランチのタイミングでIOSを18にアップグレードした。

## スクリーンショット
特になし

## その他
特になし