### PR TITLE
名刺詳細ページをDBと結合しバグ等を修正

### DIFF
--- a/lib/components/big_meishi_view.dart
+++ b/lib/components/big_meishi_view.dart
@@ -1,5 +1,6 @@
 import 'package:e_meishi/models/meishi.dart';
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
 import 'dart:io';
 import 'package:isar/isar.dart';
 import 'package:path_provider/path_provider.dart';
@@ -38,7 +39,11 @@ class BigMeishiView extends StatelessWidget {
               margin: const EdgeInsets.all(5),
               decoration: BoxDecoration(
                   border: Border.all(color: Colors.grey, width: 3)),
-              child: Image.file(File(snapshot.data!)));
+              child: InkWell(
+                  onTap: () {
+                    context.push('/detail');
+                  },
+                  child: Image.file(File(snapshot.data!))));
         },
       ),
     ]);

--- a/lib/components/confirm_dialog.dart
+++ b/lib/components/confirm_dialog.dart
@@ -1,9 +1,13 @@
+import 'package:e_meishi/utils/utils.dart';
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
 
 class ConfirmDialog extends StatelessWidget {
   final String confirmMessage;
+  final int meishiId;
 
-  const ConfirmDialog({super.key, required this.confirmMessage});
+  const ConfirmDialog(
+      {super.key, required this.confirmMessage, required this.meishiId});
 
   @override
   Widget build(BuildContext context) {
@@ -32,6 +36,8 @@ class ConfirmDialog extends StatelessWidget {
                 TextButton(
                   onPressed: () {
                     Navigator.of(context, rootNavigator: true).pop();
+                    deleteMeishi(meishiId);
+                    context.pop();
                   },
                   child: const Text('削除する'),
                 )

--- a/lib/components/confirm_dialog.dart
+++ b/lib/components/confirm_dialog.dart
@@ -1,0 +1,45 @@
+import 'package:flutter/material.dart';
+
+class ConfirmDialog extends StatelessWidget {
+  final String confirmMessage;
+
+  const ConfirmDialog({super.key, required this.confirmMessage});
+
+  @override
+  Widget build(BuildContext context) {
+    return Dialog(
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(10)),
+      child: Padding(
+        padding: const EdgeInsets.all(20),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            const Text('⚠️', style: TextStyle(fontSize: 40, color: Colors.red)),
+            Text(
+              confirmMessage,
+              textAlign: TextAlign.center,
+            ),
+            Row(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                TextButton(
+                  onPressed: () {
+                    Navigator.of(context, rootNavigator: true).pop();
+                  },
+                  child: const Text('キャンセル'),
+                ),
+                TextButton(
+                  onPressed: () {
+                    Navigator.of(context, rootNavigator: true).pop();
+                  },
+                  child: const Text('削除する'),
+                )
+              ],
+            )
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/components/grid_cards.dart
+++ b/lib/components/grid_cards.dart
@@ -48,7 +48,7 @@ class GridCards extends StatelessWidget {
                   children: [
                     InkWell(
                       onTap: () {
-                        context.push('/detail');
+                        context.push('/detail/${meishi.id}');
                       },
                       child: ClipRRect(
                         borderRadius: BorderRadius.circular(8),

--- a/lib/components/grid_cards.dart
+++ b/lib/components/grid_cards.dart
@@ -1,6 +1,7 @@
 import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:e_meishi/models/meishi.dart';
+import 'package:go_router/go_router.dart';
 import 'package:path_provider/path_provider.dart';
 import 'package:intl/intl.dart';
 
@@ -45,13 +46,18 @@ class GridCards extends StatelessWidget {
                   snapshot.hasData) {
                 return Stack(
                   children: [
-                    ClipRRect(
-                      borderRadius: BorderRadius.circular(8),
-                      child: Image.file(
-                        File(snapshot.data!),
-                        fit: BoxFit.cover,
-                        width: double.infinity,
-                        height: double.infinity,
+                    InkWell(
+                      onTap: () {
+                        context.push('/detail');
+                      },
+                      child: ClipRRect(
+                        borderRadius: BorderRadius.circular(8),
+                        child: Image.file(
+                          File(snapshot.data!),
+                          fit: BoxFit.cover,
+                          width: double.infinity,
+                          height: double.infinity,
+                        ),
                       ),
                     ),
                     Positioned(

--- a/lib/components/long_description.dart
+++ b/lib/components/long_description.dart
@@ -2,29 +2,15 @@ import 'package:flutter/material.dart';
 
 class LongDescription extends StatefulWidget {
   final String hintText;
-  final String mainText;
+  final TextEditingController controller;
   const LongDescription(
-      {super.key, required this.hintText, required this.mainText});
+      {super.key, required this.hintText, required this.controller});
 
   @override
   State<LongDescription> createState() => _LongDescriptionState();
 }
 
 class _LongDescriptionState extends State<LongDescription> {
-  final TextEditingController _controller = TextEditingController(text: '');
-
-  @override
-  void initState() {
-    super.initState();
-    _controller.text = widget.mainText;
-  }
-
-  @override
-  void dispose() {
-    _controller.dispose();
-    super.dispose();
-  }
-
   @override
   Widget build(BuildContext context) {
     return Padding(
@@ -40,7 +26,7 @@ class _LongDescriptionState extends State<LongDescription> {
             ),
           ),
           TextField(
-              controller: _controller,
+              controller: widget.controller,
               decoration: InputDecoration(
                 filled: true,
                 fillColor: Colors.grey[200],

--- a/lib/components/long_description.dart
+++ b/lib/components/long_description.dart
@@ -1,8 +1,29 @@
 import 'package:flutter/material.dart';
 
-class LongDescription extends StatelessWidget {
+class LongDescription extends StatefulWidget {
   final String hintText;
-  const LongDescription({super.key, required this.hintText});
+  final String mainText;
+  const LongDescription(
+      {super.key, required this.hintText, required this.mainText});
+
+  @override
+  State<LongDescription> createState() => _LongDescriptionState();
+}
+
+class _LongDescriptionState extends State<LongDescription> {
+  final TextEditingController _controller = TextEditingController(text: '');
+
+  @override
+  void initState() {
+    super.initState();
+    _controller.text = widget.mainText;
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -14,11 +35,12 @@ class LongDescription extends StatelessWidget {
           Padding(
             padding: const EdgeInsets.symmetric(horizontal: 8.0, vertical: 4.0),
             child: Text(
-              hintText,
+              widget.hintText,
               style: const TextStyle(fontSize: 14, fontWeight: FontWeight.bold),
             ),
           ),
           TextField(
+              controller: _controller,
               decoration: InputDecoration(
                 filled: true,
                 fillColor: Colors.grey[200],

--- a/lib/components/sample_carousel.dart
+++ b/lib/components/sample_carousel.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
 
 class SampleCarousel extends StatelessWidget {
   final String title;
@@ -36,11 +37,17 @@ class SampleCarousel extends StatelessWidget {
                         padding: const EdgeInsets.symmetric(horizontal: 4),
                         child: AspectRatio(
                           aspectRatio: 8 / 5, // アイテムのアスペクト比を指定
-                          child: ClipRRect(
-                            borderRadius: BorderRadius.circular(5), // 角丸の半径を指定
-                            child: Image.network(
-                              imageUrls[index], // 画像のURLを表示
-                              fit: BoxFit.cover, // 画像をコンテナ全体にフィット
+                          child: InkWell(
+                            onTap: () {
+                              context.push('/detail');
+                            },
+                            child: ClipRRect(
+                              borderRadius:
+                                  BorderRadius.circular(5), // 角丸の半径を指定
+                              child: Image.network(
+                                imageUrls[index], // 画像のURLを表示
+                                fit: BoxFit.cover, // 画像をコンテナ全体にフィット
+                              ),
                             ),
                           ),
                         ),

--- a/lib/components/single_line_description.dart
+++ b/lib/components/single_line_description.dart
@@ -2,7 +2,8 @@ import 'package:flutter/material.dart';
 
 class OneLineDescription extends StatelessWidget {
   final String hintText;
-  const OneLineDescription({super.key, required this.hintText});
+  final String mainText;
+  const OneLineDescription({super.key, required this.hintText, required this.mainText});
 
   @override
   Widget build(BuildContext context) {

--- a/lib/components/single_line_description.dart
+++ b/lib/components/single_line_description.dart
@@ -1,9 +1,29 @@
 import 'package:flutter/material.dart';
 
-class OneLineDescription extends StatelessWidget {
+class OneLineDescription extends StatefulWidget {
   final String hintText;
   final String mainText;
-  const OneLineDescription({super.key, required this.hintText, required this.mainText});
+  const OneLineDescription(
+      {super.key, required this.hintText, required this.mainText});
+
+  @override
+  State<OneLineDescription> createState() => _OneLineDescriptionState();
+}
+
+class _OneLineDescriptionState extends State<OneLineDescription> {
+  final TextEditingController _controller = TextEditingController(text: '');
+
+  @override
+  void initState() {
+    super.initState();
+    _controller.text = widget.mainText;
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -15,11 +35,12 @@ class OneLineDescription extends StatelessWidget {
           Padding(
             padding: const EdgeInsets.symmetric(horizontal: 8.0, vertical: 4.0),
             child: Text(
-              hintText,
+              widget.hintText,
               style: const TextStyle(fontSize: 14, fontWeight: FontWeight.bold),
             ),
           ),
           TextField(
+            controller: _controller,
             decoration: InputDecoration(
                 filled: true,
                 fillColor: Colors.grey[200],

--- a/lib/components/single_line_description.dart
+++ b/lib/components/single_line_description.dart
@@ -2,28 +2,17 @@ import 'package:flutter/material.dart';
 
 class OneLineDescription extends StatefulWidget {
   final String hintText;
-  final String mainText;
+  final TextEditingController controller;
+
   const OneLineDescription(
-      {super.key, required this.hintText, required this.mainText});
+      {super.key, required this.hintText, required this.controller});
 
   @override
   State<OneLineDescription> createState() => _OneLineDescriptionState();
 }
 
 class _OneLineDescriptionState extends State<OneLineDescription> {
-  final TextEditingController _controller = TextEditingController(text: '');
 
-  @override
-  void initState() {
-    super.initState();
-    _controller.text = widget.mainText;
-  }
-
-  @override
-  void dispose() {
-    _controller.dispose();
-    super.dispose();
-  }
 
   @override
   Widget build(BuildContext context) {
@@ -40,7 +29,7 @@ class _OneLineDescriptionState extends State<OneLineDescription> {
             ),
           ),
           TextField(
-            controller: _controller,
+            controller: widget.controller,
             decoration: InputDecoration(
                 filled: true,
                 fillColor: Colors.grey[200],

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -115,11 +115,10 @@ class MyApp extends StatelessWidget {
           },
         ),
         GoRoute(
-          path: '/detail',
+          path: '/detail/:id',
           builder: (BuildContext context, GoRouterState state) {
-            return const DetailScreen(
-              meishiId: 1,
-            );
+            return DetailScreen(
+                meishiId: int.parse(state.pathParameters['id']!));
           },
         ),
       ],

--- a/lib/screens/add/display_picture_screen.dart
+++ b/lib/screens/add/display_picture_screen.dart
@@ -58,7 +58,13 @@ class DisplayPictureScreen extends StatelessWidget {
                           // 非同期処理
                           final meishi = Meishi()
                             ..imageName = imageName
-                            ..addedTime = DateTime.now();
+                            ..addedTime = DateTime.now()
+                            ..userName = ''
+                            ..age = ''
+                            ..gender = ''
+                            ..affiliation = ''
+                            ..phoneNumber = ''
+                            ..memo = '';
 
                           await isar.writeTxn(() async {
                             await isar.meishis.put(meishi);

--- a/lib/screens/detail/detail_screen.dart
+++ b/lib/screens/detail/detail_screen.dart
@@ -61,14 +61,16 @@ class DetailScreen extends StatelessWidget {
                           ),
                           OneLineDescription(
                             hintText: '所属',
-                            mainText: meishiData?.affiliation ??
-                                '取得できませんでした',
+                            mainText: meishiData?.affiliation ?? '取得できませんでした',
                           ),
                           OneLineDescription(
                             hintText: '電話番号',
                             mainText: meishiData?.phoneNumber ?? '取得できませんでした',
                           ),
-                          const LongDescription(hintText: 'メモなど'),
+                          LongDescription(
+                            hintText: 'メモなど',
+                            mainText: meishiData?.memo ?? '取得できませんでした',
+                          ),
                         ],
                       ),
                     )

--- a/lib/screens/detail/detail_screen.dart
+++ b/lib/screens/detail/detail_screen.dart
@@ -2,6 +2,8 @@ import 'package:e_meishi/components/big_meishi_view.dart';
 import 'package:e_meishi/components/single_line_description.dart';
 import 'package:e_meishi/components/long_description.dart';
 import 'package:flutter/material.dart';
+import 'package:e_meishi/utils/utils.dart';
+import 'package:e_meishi/models/meishi.dart';
 
 class DetailScreen extends StatelessWidget {
   final int meishiId;
@@ -14,31 +16,65 @@ class DetailScreen extends StatelessWidget {
         appBar: AppBar(
           title: const Text(('名刺詳細ページ')),
         ),
-        body: SingleChildScrollView(
-          child: Column(
-            children: [
-              BigMeishiView(meishiId: meishiId),
-              const Padding(
-                padding: EdgeInsets.all(8.0),
+        body: FutureBuilder<Meishi>(
+            future: getMeishiData(meishiId),
+            builder: (context, snapshot) {
+              if (snapshot.connectionState == ConnectionState.waiting) {
+                return const Center(
+                    child: CircularProgressIndicator()); // データ取得中のローディング表示
+              } else if (snapshot.hasError) {
+                return Center(
+                    child: Text('エラーが発生しました: ${snapshot.error}')); // エラーメッセージ表示
+              } else if (!snapshot.hasData || snapshot.data == null) {
+                return const Center(child: Text('データが見つかりません')); // データがない場合の表示
+              }
+
+              final meishiData = snapshot.data;
+
+              return SingleChildScrollView(
                 child: Column(
                   children: [
-                    OneLineDescription(hintText: '名前'),
-                    Row(
-                      mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                      children: [
-                        Expanded(child: OneLineDescription(hintText: '性別')),
-                        SizedBox(width: 8),
-                        Expanded(child: OneLineDescription(hintText: '年齢')),
-                      ],
-                    ),
-                    OneLineDescription(hintText: '所属'),
-                    OneLineDescription(hintText: '電話番号'),
-                    LongDescription(hintText: 'メモなど'),
+                    BigMeishiView(meishiId: meishiId),
+                    Padding(
+                      padding: const EdgeInsets.all(8.0),
+                      child: Column(
+                        children: [
+                          OneLineDescription(
+                            hintText: '名前',
+                            mainText: meishiData?.userName ?? '取得できませんでした',
+                          ),
+                          Row(
+                            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                            children: [
+                              Expanded(
+                                  child: OneLineDescription(
+                                hintText: '性別',
+                                mainText: meishiData?.gender ?? '取得できませんでした',
+                              )),
+                              const SizedBox(width: 8),
+                              Expanded(
+                                  child: OneLineDescription(
+                                hintText: '年齢',
+                                mainText: meishiData?.age ?? '取得できませんでした',
+                              )),
+                            ],
+                          ),
+                          OneLineDescription(
+                            hintText: '所属',
+                            mainText: meishiData?.affiliation ??
+                                '取得できませんでした',
+                          ),
+                          OneLineDescription(
+                            hintText: '電話番号',
+                            mainText: meishiData?.phoneNumber ?? '取得できませんでした',
+                          ),
+                          const LongDescription(hintText: 'メモなど'),
+                        ],
+                      ),
+                    )
                   ],
                 ),
-              )
-            ],
-          ),
-        ));
+              );
+            }));
   }
 }

--- a/lib/screens/detail/detail_screen.dart
+++ b/lib/screens/detail/detail_screen.dart
@@ -4,20 +4,82 @@ import 'package:e_meishi/components/long_description.dart';
 import 'package:flutter/material.dart';
 import 'package:e_meishi/utils/utils.dart';
 import 'package:e_meishi/models/meishi.dart';
+import 'package:isar/isar.dart';
 
-class DetailScreen extends StatelessWidget {
+class DetailScreen extends StatefulWidget {
   final int meishiId;
 
   const DetailScreen({super.key, required this.meishiId});
+
+  @override
+  State<DetailScreen> createState() => _DetailScreenState();
+}
+
+class _DetailScreenState extends State<DetailScreen> {
+  late final Isar _isar;
+  final TextEditingController _nameController = TextEditingController();
+  final TextEditingController _genderController = TextEditingController();
+  final TextEditingController _ageController = TextEditingController();
+  final TextEditingController _affiliationController = TextEditingController();
+  final TextEditingController _phoneNumberController = TextEditingController();
+
+  late Future<Meishi?> _meishiData;
+
+  @override
+  void initState() {
+    super.initState();
+    _isar = Isar.getInstance()!;
+    _meishiData = getMeishiData(widget.meishiId);
+
+    // データを取得してコントローラに初期値を設定
+    _meishiData.then((meishi) {
+      if (meishi != null) {
+        _nameController.text = meishi.userName;
+        _genderController.text = meishi.gender;
+        _ageController.text = meishi.age;
+        _affiliationController.text = meishi.affiliation;
+        _phoneNumberController.text = meishi.phoneNumber;
+      }
+    });
+  }
+
+  //　コントローラーを破棄
+  @override
+  void dispose() {
+    _nameController.dispose();
+    _genderController.dispose();
+    _ageController.dispose();
+    _affiliationController.dispose();
+    _phoneNumberController.dispose();
+    super.dispose();
+  }
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
         appBar: AppBar(
           title: const Text(('名刺詳細ページ')),
+          actions: [
+            IconButton(
+              icon: const Icon(Icons.save),
+              onPressed: () => saveMeishiData(
+                      _isar,
+                      widget.meishiId,
+                      _nameController,
+                      _genderController,
+                      _ageController,
+                      _phoneNumberController,
+                      _affiliationController)
+                  .then((_) {
+                ScaffoldMessenger.of(context).showSnackBar(
+                  const SnackBar(content: Text('データが保存されました')),
+                );
+              }),
+            ),
+          ],
         ),
         body: FutureBuilder<Meishi>(
-            future: getMeishiData(meishiId),
+            future: getMeishiData(widget.meishiId),
             builder: (context, snapshot) {
               if (snapshot.connectionState == ConnectionState.waiting) {
                 return const Center(
@@ -34,14 +96,14 @@ class DetailScreen extends StatelessWidget {
               return SingleChildScrollView(
                 child: Column(
                   children: [
-                    BigMeishiView(meishiId: meishiId),
+                    BigMeishiView(meishiId: widget.meishiId),
                     Padding(
                       padding: const EdgeInsets.all(8.0),
                       child: Column(
                         children: [
                           OneLineDescription(
                             hintText: '名前',
-                            mainText: meishiData?.userName ?? '取得できませんでした',
+                            controller: _nameController,
                           ),
                           Row(
                             mainAxisAlignment: MainAxisAlignment.spaceBetween,
@@ -49,23 +111,23 @@ class DetailScreen extends StatelessWidget {
                               Expanded(
                                   child: OneLineDescription(
                                 hintText: '性別',
-                                mainText: meishiData?.gender ?? '取得できませんでした',
+                                controller: _genderController,
                               )),
                               const SizedBox(width: 8),
                               Expanded(
                                   child: OneLineDescription(
                                 hintText: '年齢',
-                                mainText: meishiData?.age ?? '取得できませんでした',
+                                controller: _ageController,
                               )),
                             ],
                           ),
                           OneLineDescription(
                             hintText: '所属',
-                            mainText: meishiData?.affiliation ?? '取得できませんでした',
+                            controller: _affiliationController,
                           ),
                           OneLineDescription(
                             hintText: '電話番号',
-                            mainText: meishiData?.phoneNumber ?? '取得できませんでした',
+                            controller: _phoneNumberController,
                           ),
                           LongDescription(
                             hintText: 'メモなど',

--- a/lib/screens/detail/detail_screen.dart
+++ b/lib/screens/detail/detail_screen.dart
@@ -22,6 +22,7 @@ class _DetailScreenState extends State<DetailScreen> {
   final TextEditingController _ageController = TextEditingController();
   final TextEditingController _affiliationController = TextEditingController();
   final TextEditingController _phoneNumberController = TextEditingController();
+  final TextEditingController _memoController = TextEditingController();
 
   late Future<Meishi?> _meishiData;
 
@@ -39,6 +40,7 @@ class _DetailScreenState extends State<DetailScreen> {
         _ageController.text = meishi.age;
         _affiliationController.text = meishi.affiliation;
         _phoneNumberController.text = meishi.phoneNumber;
+        _memoController.text = meishi.memo;
       }
     });
   }
@@ -51,6 +53,7 @@ class _DetailScreenState extends State<DetailScreen> {
     _ageController.dispose();
     _affiliationController.dispose();
     _phoneNumberController.dispose();
+    _memoController.dispose();
     super.dispose();
   }
 
@@ -69,7 +72,8 @@ class _DetailScreenState extends State<DetailScreen> {
                       _genderController,
                       _ageController,
                       _phoneNumberController,
-                      _affiliationController)
+                      _affiliationController,
+                      _memoController)
                   .then((_) {
                 ScaffoldMessenger.of(context).showSnackBar(
                   const SnackBar(content: Text('データが保存されました')),
@@ -90,8 +94,6 @@ class _DetailScreenState extends State<DetailScreen> {
               } else if (!snapshot.hasData || snapshot.data == null) {
                 return const Center(child: Text('データが見つかりません')); // データがない場合の表示
               }
-
-              final meishiData = snapshot.data;
 
               return SingleChildScrollView(
                 child: Column(
@@ -131,7 +133,7 @@ class _DetailScreenState extends State<DetailScreen> {
                           ),
                           LongDescription(
                             hintText: 'メモなど',
-                            mainText: meishiData?.memo ?? '取得できませんでした',
+                            controller: _memoController,
                           ),
                         ],
                       ),

--- a/lib/screens/detail/detail_screen.dart
+++ b/lib/screens/detail/detail_screen.dart
@@ -84,7 +84,8 @@ class _DetailScreenState extends State<DetailScreen> {
               icon: const Icon(Icons.delete),
               color: Colors.red,
               onPressed: () {
-                showConfirmDialog(context, 'この名刺を削除します。\n削除すると二度と復元はできません。');
+                showConfirmDialog(
+                    context, 'この名刺を削除します。\n削除すると二度と復元はできません。', widget.meishiId);
               },
             )
           ],

--- a/lib/screens/detail/detail_screen.dart
+++ b/lib/screens/detail/detail_screen.dart
@@ -80,6 +80,13 @@ class _DetailScreenState extends State<DetailScreen> {
                 );
               }),
             ),
+            IconButton(
+              icon: const Icon(Icons.delete),
+              color: Colors.red,
+              onPressed: () {
+                showConfirmDialog(context, 'この名刺を削除します。\n削除すると二度と復元はできません。');
+              },
+            )
           ],
         ),
         body: FutureBuilder<Meishi>(

--- a/lib/utils/utils.dart
+++ b/lib/utils/utils.dart
@@ -80,6 +80,7 @@ Future<void> saveMeishiData(
   TextEditingController ageController,
   TextEditingController phoneNumberController,
   TextEditingController affiliationController,
+    TextEditingController memoController
 ) async {
   // トランザクションでデータを保存
   await isar.writeTxn(() async {
@@ -93,7 +94,8 @@ Future<void> saveMeishiData(
       ..gender = genderController.text
       ..age = ageController.text
       ..phoneNumber = phoneNumberController.text
-      ..affiliation = affiliationController.text;
+      ..affiliation = affiliationController.text
+      ..memo = memoController.text;
 
     await isar.meishis.put(meishi);
   });

--- a/lib/utils/utils.dart
+++ b/lib/utils/utils.dart
@@ -34,10 +34,13 @@ void showErrorDialog(BuildContext context, String errorMessage) {
 }
 
 // DB関連
+
+//取得
+
 enum SortOrder { newest, oldest, marked }
 
 Future<List<Meishi>> getMeishis(SortOrder sortOrder) async {
-  final Isar? isar = Isar.getInstance(); 
+  final Isar? isar = Isar.getInstance();
   if (isar == null) {
     throw Exception('Database not available'); // ここでエラーハンドリング、または空のリストを返す等
   }
@@ -67,4 +70,31 @@ Future<Meishi> getMeishiData(meishiId) async {
     throw Exception('Meishi not found');
   }
   return meishi;
+}
+
+Future<void> saveMeishiData(
+  Isar isar,
+  int meishiId,
+  TextEditingController nameController,
+  TextEditingController genderController,
+  TextEditingController ageController,
+  TextEditingController phoneNumberController,
+  TextEditingController affiliationController,
+) async {
+  // トランザクションでデータを保存
+  await isar.writeTxn(() async {
+    final meishi = await isar.meishis.get(meishiId);
+    if (meishi == null) {
+      throw Exception('Meishi not found');
+    }
+    meishi
+      ..id = meishiId
+      ..userName = nameController.text
+      ..gender = genderController.text
+      ..age = ageController.text
+      ..phoneNumber = phoneNumberController.text
+      ..affiliation = affiliationController.text;
+
+    await isar.meishis.put(meishi);
+  });
 }

--- a/lib/utils/utils.dart
+++ b/lib/utils/utils.dart
@@ -34,12 +34,16 @@ void showErrorDialog(BuildContext context, String errorMessage) {
       });
 }
 
-void showConfirmDialog(BuildContext context, String confirmMessage) {
+void showConfirmDialog(
+    BuildContext context, String confirmMessage, int meishiId) {
   showDialog(
       context: context,
       barrierDismissible: false,
       builder: (BuildContext context) {
-        return ConfirmDialog(confirmMessage: confirmMessage);
+        return ConfirmDialog(
+          confirmMessage: confirmMessage,
+          meishiId: meishiId,
+        );
       });
 }
 
@@ -83,15 +87,14 @@ Future<Meishi> getMeishiData(meishiId) async {
 }
 
 Future<void> saveMeishiData(
-  Isar isar,
-  int meishiId,
-  TextEditingController nameController,
-  TextEditingController genderController,
-  TextEditingController ageController,
-  TextEditingController phoneNumberController,
-  TextEditingController affiliationController,
-    TextEditingController memoController
-) async {
+    Isar isar,
+    int meishiId,
+    TextEditingController nameController,
+    TextEditingController genderController,
+    TextEditingController ageController,
+    TextEditingController phoneNumberController,
+    TextEditingController affiliationController,
+    TextEditingController memoController) async {
   // トランザクションでデータを保存
   await isar.writeTxn(() async {
     final meishi = await isar.meishis.get(meishiId);
@@ -108,5 +111,16 @@ Future<void> saveMeishiData(
       ..memo = memoController.text;
 
     await isar.meishis.put(meishi);
+  });
+}
+
+void deleteMeishi(int meishiId) async {
+  final Isar? isar = Isar.getInstance();
+  if (isar == null) {
+    throw Exception('Database not available');
+  }
+
+  await isar.writeTxn(() async {
+    await isar.meishis.delete(meishiId);
   });
 }

--- a/lib/utils/utils.dart
+++ b/lib/utils/utils.dart
@@ -1,3 +1,4 @@
+import 'package:e_meishi/components/confirm_dialog.dart';
 import 'package:e_meishi/models/meishi.dart';
 import 'package:flutter/material.dart';
 import 'package:e_meishi/components/loading_dialog.dart';
@@ -30,6 +31,15 @@ void showErrorDialog(BuildContext context, String errorMessage) {
       barrierDismissible: false,
       builder: (BuildContext context) {
         return ErrorDialog(errorMessage: errorMessage);
+      });
+}
+
+void showConfirmDialog(BuildContext context, String confirmMessage) {
+  showDialog(
+      context: context,
+      barrierDismissible: false,
+      builder: (BuildContext context) {
+        return ConfirmDialog(confirmMessage: confirmMessage);
       });
 }
 

--- a/lib/utils/utils.dart
+++ b/lib/utils/utils.dart
@@ -37,7 +37,7 @@ void showErrorDialog(BuildContext context, String errorMessage) {
 enum SortOrder { newest, oldest, marked }
 
 Future<List<Meishi>> getMeishis(SortOrder sortOrder) async {
-  final Isar? isar = Isar.getInstance(); // Isarインスタンスを取得、null許容型として扱う
+  final Isar? isar = Isar.getInstance(); 
   if (isar == null) {
     throw Exception('Database not available'); // ここでエラーハンドリング、または空のリストを返す等
   }
@@ -55,4 +55,16 @@ Future<List<Meishi>> getMeishis(SortOrder sortOrder) async {
     default:
       return [];
   }
+}
+
+Future<Meishi> getMeishiData(meishiId) async {
+  final Isar? isar = Isar.getInstance();
+  if (isar == null) {
+    throw Exception('Database not available');
+  }
+  final meishi = await isar.meishis.get(meishiId);
+  if (meishi == null) {
+    throw Exception('Meishi not found');
+  }
+  return meishi;
 }


### PR DESCRIPTION
## 概要
名刺詳細ページをDBと結合した
それに伴い出現したバグなどに対処した

## プルリクについて
各機能や問題に分けてブランチを作成し、このブランチに統合してマージします。
これは名刺詳細ページの最終ブランチで、developブランチへマージするためのプルリクです。

## 対応issue
#121 #122 #124 #125 #126 #131 #134 #140 

## 更新内容
- #132 
- #133 
- #135 
- #136 
- #137 
- #138 
- #139 
- #141 

## テスト
1.アプリを起動
2.名刺管理ページに移動
3.名刺をタップし詳細ページに移動(ここで遷移に問題がないか確認)
4.TextFieldに値を入力し右上の保存ボタンを押下(SnackBarが表示されることを確認)
5.一度戻ってまた同じ名刺をタップ
6.保存と表示に問題がないか確認
7.右上の削除ボタンを押下(ダイアログを確認)
8.ダイアログのボタンを押下し動作を確認
8.画面がpopされるか確認

## 注意点
変更点や追加点に関しては各プルリクに機能ごと、問題ごとにまとめられています。
名刺詳細のDB結合にあたって名刺詳細じゃない部分に影響することがありましたが、
その場合は問題が起きた部分のみで切り分けてこのブランチにマージしています。
動作確認をして、問題がないとは確認していますが、何か問題が起きた場合は随時解消して行きます。

## スクリーンショット
<div style="display:flex;">
  <img src="https://github.com/user-attachments/assets/fb4bc166-d395-4b91-9172-921452a7b416"
width="250" alt="スクリーンショット1"  />
  <img src="https://github.com/user-attachments/assets/cd9706e2-f8ed-4bd6-8dca-6f8e20a15751"
width="250" alt="スクリーンショット2"  />
  <img src="https://github.com/user-attachments/assets/c8b37e5c-dc2e-402d-89ea-ab2191af0a20"
width="250" alt="スクリーンショット3"  />
  <img src="https://github.com/user-attachments/assets/626455a9-6941-4c64-bbe3-b98e8d42cd66"
width="250" alt="スクリーンショット4"  />
  <img src="https://github.com/user-attachments/assets/dc87d4c6-db22-48b8-910c-15e5f44ea3a2"
width="250" alt="スクリーンショット5"  />
</div>

## その他
特になし