### PR TITLE
フォントサイズをデフォルトに修正

### DIFF
--- a/lib/components/activities.dart
+++ b/lib/components/activities.dart
@@ -10,8 +10,7 @@ class Activities extends StatelessWidget {
       children: [
         const Padding(
           padding: EdgeInsets.only(left: 16, top: 16),
-          child: Text('アクティビティ',
-              style: TextStyle(fontWeight: FontWeight.bold, fontSize: 18)),
+          child: Text('アクティビティ', style: TextStyle(fontWeight: FontWeight.bold)),
         ), // 新しいテキストを追加
         GridView.builder(
           shrinkWrap: true,

--- a/lib/components/request.dart
+++ b/lib/components/request.dart
@@ -13,7 +13,6 @@ class Request extends StatelessWidget {
         child: Text(
           'こちらもお願いします',
           style: TextStyle(
-            fontSize: 18,
             fontWeight: FontWeight.bold,
           ),
         ),

--- a/lib/components/sample_carousel.dart
+++ b/lib/components/sample_carousel.dart
@@ -21,7 +21,6 @@ class SampleCarousel extends StatelessWidget {
             child: Text(
               title, // カルーセルのタイトル
               style: const TextStyle(
-                fontSize: 18,
                 fontWeight: FontWeight.bold,
               ),
             ),


### PR DESCRIPTION
## 概要
アプリ全体で使用するフォントサイズの指定を削除した

## プルリクについて
developブランチへマージするためのプルリクです。

## 対応issue
#151  

## 更新内容
- sampleCarouselのテキストサイズ指定を削除
- requestのテキストサイズ指定を削除
- activityのテキストサイズ指定を削除

## テスト
1.アプリを起動
2.アプリを動かしてテキストサイズを確認

## 注意点
サイズを18に指定していて、違和感があるなと思い検索してみると
一般的に使用されるテキストサイズは13~16だと言われており、デフォルトのサイズで十分だと判断しました

## スクリーンショット
<div style="display:flex;">
  <img src="https://github.com/user-attachments/assets/494fcb4b-56ce-49b7-8d6c-78f37e0f092e"
width="300" alt="スクリーンショット1"  />
  <img src="https://github.com/user-attachments/assets/5c026c05-caf6-4d04-95aa-af0bb8fcd362"
width="300" alt="スクリーンショット2"  />
</div>

## その他
特になし