### PR TITLE
マイページのヘッダーデザインを修正

### DIFF
--- a/lib/components/settings_button.dart
+++ b/lib/components/settings_button.dart
@@ -1,0 +1,13 @@
+import 'package:flutter/material.dart';
+
+class SettingsButton extends StatelessWidget {
+  const SettingsButton({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return IconButton(
+      icon: const Icon(Icons.settings),
+      onPressed: () {},
+    );
+  }
+}

--- a/lib/screens/my_page/my_page_screen.dart
+++ b/lib/screens/my_page/my_page_screen.dart
@@ -1,20 +1,48 @@
 import 'package:e_meishi/components/activities.dart';
 import 'package:e_meishi/components/request.dart';
+import 'package:e_meishi/utils/utils.dart';
 import 'package:flutter/material.dart';
 import 'package:e_meishi/components/big_meishi_view.dart';
 import 'package:e_meishi/components/transition_button.dart';
 
-class MyPageScreen extends StatelessWidget {
+class MyPageScreen extends StatefulWidget {
   const MyPageScreen({super.key});
+
+  @override
+  State<MyPageScreen> createState() => _MyPageScreenState();
+}
+
+class _MyPageScreenState extends State<MyPageScreen> {
+  String userName = '';
+
+  @override
+  void initState() {
+    super.initState();
+    _fetchMeishiName();
+  }
+
+  Future<void> _fetchMeishiName() async {
+    try {
+      final meishiData = await getMeishiData(1);
+      setState(() {
+        userName = meishiData.userName;
+      });
+    } catch (e) {
+      // エラーハンドリング
+      setState(() {
+        userName = '名前を取得中...';
+      });
+    }
+  }
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
       // Scaffoldで画面全体を構成
       appBar: AppBar(
-        title: const Text(
-          '田中 太郎',
-          style: TextStyle(fontWeight: FontWeight.bold, fontSize: 14),
+        title: Text(
+          userName,
+          style: const TextStyle(fontWeight: FontWeight.bold, fontSize: 14),
         ),
         shape: const Border(
           bottom: BorderSide(color: Colors.black12, width: 0.5),

--- a/lib/screens/my_page/my_page_screen.dart
+++ b/lib/screens/my_page/my_page_screen.dart
@@ -12,7 +12,13 @@ class MyPageScreen extends StatelessWidget {
     return Scaffold(
       // Scaffoldで画面全体を構成
       appBar: AppBar(
-        title: const Text('マイページ'),
+        title: const Text(
+          '田中 太郎',
+          style: TextStyle(fontWeight: FontWeight.bold, fontSize: 14),
+        ),
+        shape: const Border(
+          bottom: BorderSide(color: Colors.black12, width: 0.5),
+        ),
       ),
       body: const SingleChildScrollView(
         child: Column(

--- a/lib/screens/my_page/my_page_screen.dart
+++ b/lib/screens/my_page/my_page_screen.dart
@@ -1,5 +1,6 @@
 import 'package:e_meishi/components/activities.dart';
 import 'package:e_meishi/components/request.dart';
+import 'package:e_meishi/components/settings_button.dart';
 import 'package:e_meishi/utils/utils.dart';
 import 'package:flutter/material.dart';
 import 'package:e_meishi/components/big_meishi_view.dart';
@@ -47,6 +48,7 @@ class _MyPageScreenState extends State<MyPageScreen> {
         shape: const Border(
           bottom: BorderSide(color: Colors.black12, width: 0.5),
         ),
+        actions: const [SettingsButton()],
       ),
       body: const SingleChildScrollView(
         child: Column(


### PR DESCRIPTION
## 概要
マイページのヘッダーデザインを修正

## プルリクについて
[feature/header-ui-design](https://github.com/shi0n0/e-meishi/compare/feature/header-ui-design...feature/my-page-header)ブランチへマージするためのプルリクです。

## 対応issue
#160 

## 更新内容
- フォントサイズを14に修正
- フォントを太字に修正
- _fetchMeishiName関数を作成
- _fetchMeishiNameで名前を取得しヘッダーに表示
- 設定ボタンを作成
- 歯車ボタンをAppBarのActionsに設置

## テスト
1.アプリを起動
2.マイページに遷移しUIを確認

## 注意点
歯車ボタンを押しても現状何も起こりません。
設定ページへ遷移させる予定ですが、今回はボタンの設置だけで
設定ページの作成および遷移処理は別ブランチにて作業します。

## スクリーンショット
<div style="display:flex;">
  <img src="https://github.com/user-attachments/assets/df620f2d-b87d-4762-b5a6-77971b855c22"
width="300" alt="スクリーンショット1"  />
</div>

## その他
特になし