### PR TITLE
ホーム画面のヘッダースタイルを変更

### DIFF
--- a/lib/components/notification_button.dart
+++ b/lib/components/notification_button.dart
@@ -1,0 +1,13 @@
+import 'package:flutter/material.dart';
+
+class NotificationButton extends StatelessWidget {
+  const NotificationButton({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return IconButton(
+      onPressed: () {},
+      icon: const Icon(Icons.notifications),
+    );
+  }
+}

--- a/lib/screens/home/home_screen.dart
+++ b/lib/screens/home/home_screen.dart
@@ -1,4 +1,6 @@
+import 'package:e_meishi/components/notification_button.dart';
 import 'package:e_meishi/components/sample_carousel.dart';
+import 'package:e_meishi/components/settings_button.dart';
 import 'package:flutter/material.dart';
 import 'package:e_meishi/components/big_meishi_view.dart';
 import 'package:e_meishi/components/add_meishi_button.dart';
@@ -10,7 +12,14 @@ class HomeScreen extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: const Text('ホーム')),
+      appBar: AppBar(
+        centerTitle: false,
+        title: const Text(
+          'e名刺',
+          style: TextStyle(fontWeight: FontWeight.bold),
+        ),
+        actions: const [NotificationButton(), SettingsButton()],
+      ),
       body: const Stack(
         children: [
           SingleChildScrollView(


### PR DESCRIPTION
## 概要
ホーム画面のヘッダースタイルを変更した

## プルリクについて
[feature/header-ui-design](https://github.com/shi0n0/e-meishi/compare/feature/header-ui-design...feature/my-page-header)ブランチへマージするためのプルリクです。

## 対応issue
#159 

## 更新内容
- titleを左寄せに修正
- フォントを太字に修正
- notification_button(通知ボタン)を作成
- 通知ボタンと設定ボタンをactionsに設置

## テスト
1.アプリを起動
2.ホーム画面を起動しヘッダーを確認

## 注意点
通知ボタンと歯車ボタンを押しても何も起こりません。
ボタンの動作や押した先の遷移ページなどは別のブランチにて作成します。

## スクリーンショット
<div style="display:flex;">
  <img src="https://github.com/user-attachments/assets/cc044749-1bfc-4a26-b76b-bac3118e2a98"
width="300" alt="スクリーンショット1"  />
</div>

## その他
特になし