### PR TITLE
名刺履歴ページのヘッダースタイルを修正

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -89,11 +89,10 @@ class MyApp extends StatelessWidget {
               ),
               routes: <GoRoute>[
                 GoRoute(
-                  path: 'history',
-                  pageBuilder: (context, state) => NoTransitionPage(
-                    child: HistoryScreen(),
-                  ),
-                ),
+                    path: 'history',
+                    builder: (BuildContext context, GoRouterState state) {
+                      return HistoryScreen();
+                    }),
               ],
             ),
           ],

--- a/lib/screens/history/history_screen.dart
+++ b/lib/screens/history/history_screen.dart
@@ -22,15 +22,18 @@ class HistoryScreen extends StatelessWidget {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: const Text('名刺履歴'),
+        title: const Text(
+          '名刺履歴',
+          style: TextStyle(fontSize: 14, fontWeight: FontWeight.bold),
+        ),
       ),
-      body: Padding(
-        padding: const EdgeInsets.all(8.0),
+      body: const Padding(
+        padding: EdgeInsets.all(8.0),
         child: SingleChildScrollView(
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
-              const Padding(
+              Padding(
                 padding: EdgeInsets.all(8.0),
                 child: FittedBox(
                   child: Text(
@@ -43,13 +46,13 @@ class HistoryScreen extends StatelessWidget {
                   ),
                 ),
               ),
-              const BigMeishiView(meishiId: 1),
-              const SizedBox(height: 8.0), // Dividerとのスペースを作る
-              const Divider(
+              BigMeishiView(meishiId: 1),
+              SizedBox(height: 8.0), // Dividerとのスペースを作る
+              Divider(
                 thickness: 1,
                 color: Colors.grey,
               ),
-              const Padding(
+              Padding(
                 padding: EdgeInsets.all(8.0),
                 child: FittedBox(
                   child: Text(
@@ -62,10 +65,10 @@ class HistoryScreen extends StatelessWidget {
                   ),
                 ),
               ),
-              GridCards(
-                list: list,
-                isScrollable: false,
-              )
+              // GridCards(
+              //   list: list,
+              //   isScrollable: false,
+              // )
             ],
           ),
         ),

--- a/lib/screens/history/history_screen.dart
+++ b/lib/screens/history/history_screen.dart
@@ -24,7 +24,7 @@ class HistoryScreen extends StatelessWidget {
       appBar: AppBar(
         title: const Text(
           '名刺履歴',
-          style: TextStyle(fontSize: 14, fontWeight: FontWeight.bold),
+          style: TextStyle(fontSize: 16, fontWeight: FontWeight.bold),
         ),
       ),
       body: const Padding(


### PR DESCRIPTION
## 概要
名刺履歴ページのヘッダースタイルを修正

## プルリクについて
[feature/header-ui-design](https://github.com/shi0n0/e-meishi/compare/feature/header-ui-design...feature/my-page-header)ブランチへマージするためのプルリクです。

## 対応issue
#161 

## 更新内容
- AppBarのタイトルのサイズを14
- AppBarのタイトルの太さをBold

## テスト
1.アプリを起動
2.マイページに遷移
3.名刺履歴ページに遷移

## 注意点
特になし

## スクリーンショット
<div style="display:flex;">
  <img src="https://github.com/user-attachments/assets/e65cd096-8dd4-47bf-b9a6-5614c6fdcc94"
width="300" alt="スクリーンショット1"  />
</div>

## その他
特になし