### PR TITLE
名刺撮影画面のヘッダースタイルを修正

### DIFF
--- a/lib/screens/add/add_meishi.dart
+++ b/lib/screens/add/add_meishi.dart
@@ -17,7 +17,11 @@ class _AddMeishiScreenState extends State<AddMeishiScreen> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: const Text('名刺を撮影')),
+      appBar: AppBar(
+          title: const Text(
+        '名刺撮影',
+        style: TextStyle(fontSize: 16, fontWeight: FontWeight.bold),
+      )),
       body: Stack(
         children: [
           CameraScreen(camera: widget.camera),


### PR DESCRIPTION
## 概要
名刺撮影画面のヘッダースタイルを修正

## プルリクについて
[feature/header-ui-design](https://github.com/shi0n0/e-meishi/compare/feature/header-ui-design...feature/my-page-header)ブランチへマージするためのプルリクです。

## 対応issue
#162 

## 更新内容
- AppBarのタイトルのサイズを16
- AppBarのタイトルの太さをBold

## テスト
1.アプリを起動
2.ホームに遷移
3.右下の追加ボタンを押下
4.名刺撮影画面に遷移
5.ヘッダーを確認

## 注意点
特になし

## スクリーンショット
<div style="display:flex;">
  <img src="https://github.com/user-attachments/assets/6cdf5ca6-0ecd-418b-a74f-ff785ca4b2a3"
width="300" alt="スクリーンショット1"  />
</div>

## その他
ヘッダーを透過して戻るボタンだけ表示する形式にしようとしたところ、
ガイドがヘッダーの高さを無視して上に詰めるようになってしまい
撮影した後上から規定の高さを切り抜く仕組みになっているため、実現には至りませんでした。
AppBarの高さが維持したままカメラの要素を設置できるなら良かったので、
改良できる時にまた新しく対応したいと思います。