### PR TITLE
名刺プレビュー画面のヘッダーを改善

### DIFF
--- a/lib/components/cancel_button.dart
+++ b/lib/components/cancel_button.dart
@@ -1,0 +1,16 @@
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+
+class CancelButton extends StatelessWidget {
+  final String targetScreen; // 変数を宣言
+  const CancelButton({super.key, required this.targetScreen});
+
+  @override
+  Widget build(BuildContext context) {
+    return IconButton(
+        onPressed: () {
+          context.go(targetScreen);
+        },
+        icon: const Icon(Icons.close));
+  }
+}

--- a/lib/screens/add/display_picture_screen.dart
+++ b/lib/screens/add/display_picture_screen.dart
@@ -1,4 +1,5 @@
 import 'dart:io';
+import 'package:e_meishi/components/cancel_button.dart';
 import 'package:isar/isar.dart';
 import 'package:e_meishi/models/meishi.dart';
 import 'package:flutter/material.dart';
@@ -25,9 +26,11 @@ class DisplayPictureScreen extends StatelessWidget {
       },
       child: Scaffold(
         appBar: AppBar(
-          title: const Text('撮影した写真'),
-          automaticallyImplyLeading: false,
-        ),
+            title: const Text(
+              'プレビュー',
+              style: TextStyle(fontSize: 14, fontWeight: FontWeight.bold),
+            ),
+            leading: const CancelButton(targetScreen: '/home')),
         body: Stack(
           children: [
             Image.file(File(imagePath)),


### PR DESCRIPTION
## 概要
名刺プレビュー画面のヘッダースタイルを改善

## プルリクについて
[feature/header-ui-design](https://github.com/shi0n0/e-meishi/compare/feature/header-ui-design...feature/my-page-header)ブランチへマージするためのプルリクです。

## 対応issue
#163 

## 更新内容
- cancel_buttonコンポーネント作成
- ヘッダーのleadingに設置
- テキストスタイルを修正

## テスト
1.アプリを起動
2.ホームに遷移
3.右下の追加ボタンを押下
4.名刺撮影画面に遷移
5.シャッターを切り、プレビュー画面に遷移
6.ヘッダーを確認

## 注意点
cancel_buttonはtargetScreenという変数を引数として受け取ります。
targetScreenを引数に指定することで設置するページごとに遷移する先を変更できます。

## スクリーンショット
<div style="display:flex;">
  <img src="https://github.com/user-attachments/assets/4f64126e-1072-4e25-830e-16b82c5fe46c"
width="300" alt="スクリーンショット1"  />
</div>


## その他
ヘッダーの操作としてはホームに戻るしか無いですが、bodyにて取り直しの遷移と保存の処理→保存した名刺の詳細画面に遷移する処理を書くので問題はないです。
強いて言うならば複数枚登録したい時に不便なので、まとめて登録できる処理を作るのも検討しています。
その際ヘッダーに変更があるならまた別ブランチにて作業します。