### PR TITLE
名刺詳細ページのヘッダーを改善

### DIFF
--- a/lib/screens/detail/detail_screen.dart
+++ b/lib/screens/detail/detail_screen.dart
@@ -61,7 +61,11 @@ class _DetailScreenState extends State<DetailScreen> {
   Widget build(BuildContext context) {
     return Scaffold(
         appBar: AppBar(
-          title: const Text(('名刺詳細ページ')),
+          title: const Text(
+            '名刺詳細ページ',
+            style: TextStyle(fontSize: 14, fontWeight: FontWeight.bold),
+          ),
+          centerTitle: true,
           actions: [
             IconButton(
               icon: const Icon(Icons.save),


### PR DESCRIPTION
## 概要
名刺詳細画面のヘッダースタイルを改善

## プルリクについて
[feature/header-ui-design](https://github.com/shi0n0/e-meishi/compare/feature/header-ui-design...feature/my-page-header)ブランチへマージするためのプルリクです。

## 対応issue
#164 

## 更新内容
- titleのsizeを14にした
- titleのfontweightをboldにした
- centerTitleを設定

## テスト
1.アプリを起動
2.名刺管理へ遷移
3.名刺をタップ
4.名刺詳細に遷移
5.ヘッダーを確認

## 注意点
特になし

## スクリーンショット
<div style="display:flex;">
  <img src="https://github.com/user-attachments/assets/94da7a59-d81b-4359-a1ac-1ce4a14f67c5"
width="300" alt="スクリーンショット1"  />
</div>

## その他
bodyの部分に保存ボタンを移動しようと考えています。
今回は一応残しておきますが、必要ないと考えた場合は後から削除します。