### PR TITLE
設定ページのルートを作成

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -3,6 +3,7 @@ import 'package:e_meishi/screens/add/add_meishi.dart';
 import 'package:e_meishi/screens/add/display_picture_screen.dart';
 import 'package:e_meishi/screens/detail/detail_screen.dart';
 import 'package:e_meishi/screens/history/history_screen.dart';
+import 'package:e_meishi/screens/setting/setting_screen.dart';
 import 'package:flutter/foundation.dart';
 import 'screens/management/management_screen.dart';
 import 'screens/main/main_screen.dart';
@@ -122,6 +123,11 @@ class MyApp extends StatelessWidget {
                 meishiId: int.parse(state.pathParameters['id']!));
           },
         ),
+        GoRoute(
+            path: '/setting',
+            builder: (BuildContext context, GoRouterState state) {
+              return const SettingScreen();
+            }),
       ],
     );
 

--- a/lib/screens/setting/setting_screen.dart
+++ b/lib/screens/setting/setting_screen.dart
@@ -1,0 +1,11 @@
+import 'package:flutter/material.dart';
+
+class SettingScreen extends StatelessWidget {
+  const SettingScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const Scaffold(
+    );
+  }
+}


### PR DESCRIPTION
## 概要
設定ページのルートを作成

## プルリクについて
[feature/setting-page](https://github.com/shi0n0/e-meishi/tree/feature/setting-page)ブランチへマージするためのプルリクです。

## 対応issue
#176 

## 更新内容
- main.dartに/settingルートを作成
- returnにSettinScreenを記述
- setting_screen.dartを作成

## テスト
initialPageを/settingにすればデバッグできますが、ルートを作成しただけなので特にテスト要件はありません

## 注意点
特になし

## スクリーンショット
UIの変化はないので特になし

## その他
現時点ではルート作成だけで何もありません。
scaffoldを設定してあるので遷移はできますが、真っ白なままです。
今後別のブランチにて追加していきます。