### PR TITLE
設定ボタンに設定ページへの遷移処理を追加

### DIFF
--- a/lib/components/settings_button.dart
+++ b/lib/components/settings_button.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
 
 class SettingsButton extends StatelessWidget {
   const SettingsButton({super.key});
@@ -7,7 +8,9 @@ class SettingsButton extends StatelessWidget {
   Widget build(BuildContext context) {
     return IconButton(
       icon: const Icon(Icons.settings),
-      onPressed: () {},
+      onPressed: () {
+        context.go('/setting');
+      },
     );
   }
 }


### PR DESCRIPTION
## 概要
設定ボタンに設定ページへの遷移処理を追加

## プルリクについて
[feature/setting-page-header](https://github.com/shi0n0/e-meishi/tree/feature/setting-page-header)ブランチへマージするためのプルリクです。

## 対応issue
#181 

## 更新内容
- onpressedにcontext.goを記述し遷移処理を追加

## テスト
1.アプリを起動
2.ホームなどから設定ボタンを押下
3.遷移するか確認(真っ白な画面)

## 注意点
遷移はできますが、現状では真っ白な画面で戻れません。

## スクリーンショット
UIの変化はないので特になし(真っ白な画面があるだけ)

## その他
特になし