### PR TITLE
設定ページのヘッダーを作成

### DIFF
--- a/lib/components/settings_button.dart
+++ b/lib/components/settings_button.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
 
 class SettingsButton extends StatelessWidget {
   const SettingsButton({super.key});
@@ -7,7 +8,9 @@ class SettingsButton extends StatelessWidget {
   Widget build(BuildContext context) {
     return IconButton(
       icon: const Icon(Icons.settings),
-      onPressed: () {},
+      onPressed: () {
+        context.go('/setting');
+      },
     );
   }
 }

--- a/lib/components/settings_button.dart
+++ b/lib/components/settings_button.dart
@@ -9,7 +9,7 @@ class SettingsButton extends StatelessWidget {
     return IconButton(
       icon: const Icon(Icons.settings),
       onPressed: () {
-        context.go('/setting');
+        context.push('/setting');
       },
     );
   }

--- a/lib/screens/setting/setting_screen.dart
+++ b/lib/screens/setting/setting_screen.dart
@@ -5,7 +5,13 @@ class SettingScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return const Scaffold(
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text(
+          '設定',
+          style: TextStyle(fontSize: 14, fontWeight: FontWeight.bold),
+        ),
+      ),
     );
   }
 }


### PR DESCRIPTION
## 概要
設定ページのヘッダーを作成

## プルリクについて
[feature/setting-page](https://github.com/shi0n0/e-meishi/tree/feature/setting-page)ブランチへマージするためのプルリクです。

## 対応issue
#167 

## 更新内容
- AppBarを追加
- titleにTextを記述

## テスト
1.アプリを起動
2.ホームなどから設定ボタンを押下
3.設定に遷移
4.AppBarを確認

## 注意点
特になし

## スクリーンショット
<div style="display:flex;">
  <img src="https://github.com/user-attachments/assets/c5c69379-5055-439d-8497-ceda414684f2"
width="300" alt="スクリーンショット1"  />
</div>

## その他
ボタンに遷移を追加する別のブランチにてcontext.goで実装したのですが、それでは履歴が残らず戻るボタンが表示されないため、このブランチにて.pushに変更する処理に修正しました。
とても小さいコミットのためこのブランチで対応