### PR TITLE
AppBarの下に下線を追加

### DIFF
--- a/lib/screens/setting/setting_screen.dart
+++ b/lib/screens/setting/setting_screen.dart
@@ -7,6 +7,9 @@ class SettingScreen extends StatelessWidget {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
+        shape: const Border(
+          bottom: BorderSide(color: Colors.black12, width: 0.5),
+        ),
         title: const Text(
           '設定',
           style: TextStyle(fontSize: 14, fontWeight: FontWeight.bold),


### PR DESCRIPTION
## 概要
設定ページのヘッダーに下線を追加

## プルリクについて
[feature/setting-page-list](https://github.com/shi0n0/e-meishi/tree/feature/setting-page-list)ブランチへマージするためのプルリクです。

## 対応issue
#200 

## 更新内容
- AppBarの下にDividerを追加

## テスト
1.アプリを起動
2.ホームなどから設定ボタンを押下
3.設定に遷移
4.AppBarを確認

## 注意点
特になし

## スクリーンショット
<div style="display:flex;">
  <img src="https://github.com/user-attachments/assets/e3be7c11-b6ca-49f9-87fd-33948ef04bca"
width="300" alt="スクリーンショット1"  />
</div>

## その他
今回はAppBarの下にリストを表示する関係上下線がないと違和感があるため実装しました。
全体的に見て色や太さ等また修正点が出てきた場合は都度修正します。